### PR TITLE
build-sourcemaps

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,7 @@ const extractSass = new ExtractTextPlugin('romper.css');
 
 const config = {
     entry: './src/romper.js',
+    devtool: 'source-map',
     output: {
         path: path.resolve(__dirname, 'dist'),
         filename: 'romper.js',


### PR DESCRIPTION
Output _sourcemaps_ during the _webpack_ build process. These are written to the _dist_ folder as `*.map` files. The _sourcemaps_ can then be used in projects that depend upon romper.