### PR TITLE
no longer set first overlay icon as selected - make it be explicitly set

### DIFF
--- a/src/Player.js
+++ b/src/Player.js
@@ -53,11 +53,7 @@ function createOverlay(name: string, logFunction: Function) {
 
     const add = (id: string, el: HTMLElement) => {
         elements[id] = el;
-        if (Object.keys(elements).length === 1) {
-            el.classList.add('romper-control-selected');
-        } else {
-            el.classList.add('romper-control-unselected');
-        }
+        el.classList.add('romper-control-unselected');
         overlay.appendChild(el);
         button.classList.remove('romper-inactive');
     };


### PR DESCRIPTION
Minor change.  Basically, Player was automatically giving the first icon it received a 'selected' class, but now decided this should be done explicitly.  This means we don't see the first chapter marker before we even get to the first chapter