### PR TITLE
Changed romper to gracefully handle no HLS support.

### DIFF
--- a/src/HlsManager.js
+++ b/src/HlsManager.js
@@ -117,8 +117,7 @@ export default class HlsManager {
         });
     }
 
-    // eslint-disable-next-line class-methods-use-this
-    isSupported() {
+    static isSupported() {
         return Hls.isSupported();
     }
 }

--- a/src/Player.js
+++ b/src/Player.js
@@ -136,11 +136,14 @@ class Player extends EventEmitter {
 
     constructor(target: HTMLElement, analytics: AnalyticsLogger) {
         super();
+
+        this._hlsManager = new HlsManager();
+
         this.showingSubtitles = false;
 
         this._analytics = analytics;
         this._logUserInteraction = this._logUserInteraction.bind(this);
-        this._hlsManager = new HlsManager();
+
 
         this._player = document.createElement('div');
         this._player.classList.add('romper-player');

--- a/src/assets/styles/player.scss
+++ b/src/assets/styles/player.scss
@@ -31,6 +31,20 @@ $romper-background-color: #ccc;
   }
 }
 
+.romper-no-hls-support {
+  display: table;
+  height: 100%;
+  width: 100%;
+
+  div {
+    color: $accent-colour;
+    display: table-cell;
+    padding: 20px;
+    text-align: center;
+    vertical-align: middle;
+  }
+}
+
 .romper-player {
   color: $accent-colour;
   display: flex;

--- a/src/renderers/BackgroundAudioRenderer.js
+++ b/src/renderers/BackgroundAudioRenderer.js
@@ -24,9 +24,7 @@ export default class BackgroundAudioRenderer extends BackgroundRenderer {
         this._target = this._player.backgroundTarget;
 
         this._hlsManager = player._hlsManager;
-        if (this._hlsManager.isSupported()) {
-            this._hls = this._hlsManager.getHlsFromPool();
-        }
+        this._hls = this._hlsManager.getHlsFromPool();
     }
 
     start() {

--- a/src/renderers/SimpleAVRenderer.js
+++ b/src/renderers/SimpleAVRenderer.js
@@ -51,9 +51,8 @@ export default class SimpleAVRenderer extends BaseRenderer {
 
         this._hlsManager = player._hlsManager;
 
-        if (this._hlsManager.isSupported()) {
-            this._hls = this._hlsManager.getHlsFromPool();
-        }
+        this._hls = this._hlsManager.getHlsFromPool();
+
         this.renderVideoElement();
         this._handlePlayPauseButtonClicked = this._handlePlayPauseButtonClicked.bind(this);
         this._handleVolumeClicked = this._handleVolumeClicked.bind(this);

--- a/src/romper.js
+++ b/src/romper.js
@@ -3,10 +3,12 @@
 import ObjectDataResolver from './resolvers/ObjectDataResolver';
 import type { Settings } from './romper';
 import Controller from './Controller';
+
 // eslint-disable-next-line import/no-named-as-default
 import StoryReasonerFactory from './StoryReasonerFactory';
 import RepresentationReasonerFactory from './RepresentationReasoner';
 import MediaFetcher from './fetchers/MediaFetcher';
+import HlsManager from './HlsManager';
 import logger from './logger';
 
 // @flowignore
@@ -31,8 +33,21 @@ module.exports = {
         FROM_OBJECT: ObjectDataResolver,
     },
 
-    init: (settings: Settings) => {
+    init: (settings: Settings): ?Controller => {
         const mergedSettings = Object.assign({}, DEFAULT_SETTINGS, settings);
+
+        if (!HlsManager.isSupported()) {
+            const noHlsWarning = document.createElement('div');
+            noHlsWarning.classList.add('romper-no-hls-support');
+            const noHlsWarningDiv = document.createElement('div');
+            noHlsWarningDiv.classList.add('romper-no-hls-support-div');
+            noHlsWarningDiv.innerHTML = 'Your browser is not compatible with this experience. ' +
+                'Please use Chrome or Firefox and update them to the newest version.';
+
+            noHlsWarning.appendChild(noHlsWarningDiv);
+            mergedSettings.target.appendChild(noHlsWarning);
+            return null;
+        }
 
         const storyReasonerFactory = StoryReasonerFactory(
             mergedSettings.storyFetcher,


### PR DESCRIPTION
Romper will return null and show an error message if no HLS support. Can be tested by changing the return value of isSupported() in HlsManager.js to false.