### PR TITLE
Fixes Hls Memory Leaks & Playback Issues

### DIFF
--- a/src/renderers/BackgroundAudioRenderer.js
+++ b/src/renderers/BackgroundAudioRenderer.js
@@ -24,7 +24,7 @@ export default class BackgroundAudioRenderer extends BackgroundRenderer {
         this._target = this._player.backgroundTarget;
 
         this._hlsManager = player._hlsManager;
-        this._hls = this._hlsManager.getHlsFromPool();
+        this._hls = this._hlsManager.getHls();
     }
 
     start() {
@@ -99,7 +99,7 @@ export default class BackgroundAudioRenderer extends BackgroundRenderer {
         this._player.removeVolumeControl(this._assetCollection.id);
         this._player.removeListener(PlayerEvents.VOLUME_CHANGED, this._handleVolumeClicked);
 
-        this._hlsManager.returnHlsToPool(this._hls);
+        this._hlsManager.returnHls(this._hls);
         super.destroy();
     }
 }

--- a/src/renderers/SimpleAVRenderer.js
+++ b/src/renderers/SimpleAVRenderer.js
@@ -51,8 +51,7 @@ export default class SimpleAVRenderer extends BaseRenderer {
 
         this._hlsManager = player._hlsManager;
 
-        this._hls = this._hlsManager.getHlsFromPool();
-
+        this._hls = this._hlsManager.getHls();
         this.renderVideoElement();
         this._handlePlayPauseButtonClicked = this._handlePlayPauseButtonClicked.bind(this);
         this._handleVolumeClicked = this._handleVolumeClicked.bind(this);
@@ -335,7 +334,7 @@ export default class SimpleAVRenderer extends BaseRenderer {
     destroy() {
         this.end();
 
-        this._hlsManager.returnHlsToPool(this._hls);
+        this._hlsManager.returnHls(this._hls);
 
         delete this._videoTrack;
         delete this._videoElement;


### PR DESCRIPTION
Brought back Hls.destroy method instead of the pooling.
Pooling failed as old videos would often be played out instead of the one most recently requested. With destroy this is no longer possible as each hls is a separate instance so carries none of the buffers from old hls players.

hls.destroy leaked memory quite significantly before and hence it was removed. This was a combination of chrome on linux being broken (the main browser I was testing it on) and I think the fact that if the event listeners are not removed from the hls player it is not destroyed properly hence why chrome leaked memory and firefox leaked too.

Using the proper destroy method of HLS and also cleaning up all event listeners seems to fix the memory leaking issues but this will need to be properly soak tested.