### PR TITLE
Player style fix

### DIFF
--- a/src/assets/styles/player.scss
+++ b/src/assets/styles/player.scss
@@ -503,6 +503,7 @@ $romper-hover-text-size: 25px;
   }
 
   >.romper-buttons-activate-area {
+    bottom: 0;
     display: block;
     height: 13%;
     max-height: $romper-buttons-max-height;


### PR DESCRIPTION
This makes sure that the relevant controls are at least usable in standalone romper.

Styling could be improved, and we still use GEL icons, but it's a start.

In order not to break storyplayer, there will be a PR in there that modifies how this css is over-ridden.