### PR TITLE
Moved colour overlay, image and wait button behaviours to BaseRenderer

### DIFF
--- a/src/renderers/ImageRenderer.js
+++ b/src/renderers/ImageRenderer.js
@@ -8,7 +8,6 @@ import type { AnalyticsLogger } from '../AnalyticEvents';
 
 export default class ImageRenderer extends BaseRenderer {
     _imageElement: HTMLImageElement;
-    _target: HTMLDivElement;
     _disablePlayButton: Function;
     _disableScrubBar: Function;
     _enablePlayButton: Function;
@@ -23,7 +22,6 @@ export default class ImageRenderer extends BaseRenderer {
         analytics: AnalyticsLogger,
     ) {
         super(representation, assetCollectionFetcher, fetchMedia, player, analytics);
-        this._target = this._player.mediaTarget;
         this.renderImageElement();
         this._disablePlayButton = () => { this._player.disablePlayButton(); };
         this._enablePlayButton = () => { this._player.enablePlayButton(); };
@@ -62,24 +60,6 @@ export default class ImageRenderer extends BaseRenderer {
         }
 
         this._target.appendChild(this._imageElement);
-    }
-
-    renderDataModelInfo() {
-        const assetList = document.createElement('ul');
-        const foregroundItem = document.createElement('li');
-        assetList.appendChild(foregroundItem);
-        this._target.appendChild(assetList);
-
-
-        if (this._representation.asset_collections.foreground_id) {
-            this._fetchAssetCollection(this._representation.asset_collections.foreground_id)
-                .then((fg) => {
-                    foregroundItem.textContent = `foreground: ${fg.name}`;
-                    if (fg.assets.image_src) {
-                        foregroundItem.textContent += ` from ${fg.assets.image_src}`;
-                    }
-                });
-        }
     }
 
     switchFrom() {

--- a/src/renderers/SimpleAVRenderer.js
+++ b/src/renderers/SimpleAVRenderer.js
@@ -24,13 +24,7 @@ export default class SimpleAVRenderer extends BaseRenderer {
     _fetchMedia: MediaFetcher;
     _mediaInstance: MediaInstance;
     _videoTrack: HTMLTrackElement;
-    _canvas: HTMLCanvasElement;
     _applyBlurBehaviour: Function;
-    _applyColourOverlayBehaviour: Function;
-    _applyShowImageBehaviour: Function;
-    _applyWaitForButtonBehaviour: Function;
-    _behaviourElements: Array<HTMLElement>;
-    _target: HTMLDivElement;
     _handlePlayPauseButtonClicked: Function;
     _handleVolumeClicked: Function;
     _handleSubtitlesClicked: Function;
@@ -66,19 +60,13 @@ export default class SimpleAVRenderer extends BaseRenderer {
         this._pauseEventListener = this._pauseEventListener.bind(this);
 
         this._mediaManager = player._mediaManager;
-
         this._mediaInstance = this._mediaManager.getMediaInstance('foreground');
 
         this.renderVideoElement();
         this._handlePlayPauseButtonClicked = this._handlePlayPauseButtonClicked.bind(this);
         this._handleVolumeClicked = this._handleVolumeClicked.bind(this);
 
-        this._target = player.mediaTarget;
         this._applyBlurBehaviour = this._applyBlurBehaviour.bind(this);
-        this._applyColourOverlayBehaviour = this._applyColourOverlayBehaviour.bind(this);
-        this._applyShowImageBehaviour = this._applyShowImageBehaviour.bind(this);
-        this._applyWaitForButtonBehaviour = this._applyWaitForButtonBehaviour.bind(this);
-        this._behaviourElements = [];
 
         this._subtitlesShowing = player.showingSubtitles;
         this._subtitlesLoaded = false;
@@ -96,15 +84,8 @@ export default class SimpleAVRenderer extends BaseRenderer {
         };
         this._disableSubtitlesButton = () => { player.disableSubtitlesControl(); };
 
-        this._behaviourRendererMap = {
-            'urn:x-object-based-media:representation-behaviour:blur/v1.0': this._applyBlurBehaviour,
-            // eslint-disable-next-line max-len
-            'urn:x-object-based-media:representation-behaviour:colouroverlay/v1.0': this._applyColourOverlayBehaviour,
-            // eslint-disable-next-line max-len
-            'urn:x-object-based-media:representation-behaviour:showimage/v1.0': this._applyShowImageBehaviour,
-            // eslint-disable-next-line max-len
-            'urn:x-object-based-media:representation-behaviour:showwaitbutton/v1.0': this._applyWaitForButtonBehaviour,
-        };
+        // eslint-disable-next-line max-len
+        this._behaviourRendererMap['urn:x-object-based-media:representation-behaviour:blur/v1.0'] = this._applyBlurBehaviour;
 
         this._lastSetTime = 0;
     }
@@ -161,8 +142,6 @@ export default class SimpleAVRenderer extends BaseRenderer {
         this._mediaInstance.play();
 
         this._enableSubtitlesButton();
-
-        this._clearBehaviourElements();
     }
 
     end() {
@@ -305,71 +284,6 @@ export default class SimpleAVRenderer extends BaseRenderer {
         callback();
     }
 
-    _applyColourOverlayBehaviour(behaviour: Object, callback: () => mixed) {
-        const { colour } = behaviour;
-        const overlayImageElement = document.createElement('div');
-        overlayImageElement.style.background = colour;
-        overlayImageElement.className = 'romper-image-overlay';
-        this._target.appendChild(overlayImageElement);
-        this._behaviourElements.push(overlayImageElement);
-        callback();
-    }
-
-    _applyShowImageBehaviour(behaviour: Object, callback: () => mixed) {
-        const behaviourAssetCollectionMappingId = behaviour.image;
-        const assetCollectionId =
-            this.resolveBehaviourAssetCollectionMappingId(behaviourAssetCollectionMappingId);
-        if (assetCollectionId) {
-            this._fetchAssetCollection(assetCollectionId).then((image) => {
-                if (image.assets.image_src) {
-                    this._overlayImage(image.assets.image_src);
-                    callback();
-                }
-            });
-        }
-    }
-
-    _applyWaitForButtonBehaviour(behaviour: Object, callback: () => mixed) {
-        const continueButton = document.createElement('button');
-        continueButton.classList.add(behaviour.button_class);
-        continueButton.setAttribute('title', 'Continue Button');
-        continueButton.setAttribute('aria-label', 'Continue Button');
-        const continueButtonIconDiv = document.createElement('div');
-        continueButtonIconDiv.classList.add('romper-button-icon-div');
-        continueButtonIconDiv.classList.add(`${behaviour.button_class}-icon-div`);
-        continueButton.appendChild(continueButtonIconDiv);
-        const continueButtonTextDiv = document.createElement('div');
-        continueButtonTextDiv.innerHTML = behaviour.text;
-        continueButtonTextDiv.classList.add('romper-button-text-div');
-        continueButtonTextDiv.classList.add(`${behaviour.button_class}-text-div`);
-        continueButton.appendChild(continueButtonTextDiv);
-
-        this._target.appendChild(continueButton);
-        this._behaviourElements.push(continueButton);
-
-        const buttonClickHandler = () => {
-            this._player._enableUserInteraction();
-            this._player._narrativeElementTransport.classList.remove('romper-inactive');
-            this.logUserInteraction(AnalyticEvents.names.BEHAVIOUR_CONTINUE_BUTTON_CLICKED);
-            callback();
-        };
-        continueButton.onclick = buttonClickHandler;
-
-        if (behaviour.hide_narrative_buttons) {
-            // can't use player.setNextAvailable
-            // as this may get reset after this by NE change handling
-            this._player._narrativeElementTransport.classList.add('romper-inactive');
-        }
-    }
-
-    _overlayImage(imageSrc: string) {
-        const overlayImageElement = document.createElement('img');
-        overlayImageElement.src = imageSrc;
-        overlayImageElement.className = 'romper-image-overlay';
-        this._target.appendChild(overlayImageElement);
-        this._behaviourElements.push(overlayImageElement);
-    }
-
     _handlePlayPauseButtonClicked(): void {
         const videoElement = this._mediaInstance.getMediaElement();
         if (videoElement.paused === true) {
@@ -435,15 +349,9 @@ export default class SimpleAVRenderer extends BaseRenderer {
     }
 
     _clearBehaviourElements() {
+        super._clearBehaviourElements();
         const videoElement = this._mediaInstance.getMediaElement();
         videoElement.style.filter = ''; // eslint-disable-line prefer-destructuring
-        this._behaviourElements.forEach((be) => {
-            try {
-                this._target.removeChild(be);
-            } catch (e) {
-                logger.warn(`could not remove behaviour element ${be.id} from SimpleAVRenderer`);
-            }
-        });
     }
 
     destroy() {


### PR DESCRIPTION
This allows them to be applied to any representation, so a story can start with an image/audio/text which has a wait button, so that later video elements can play in iOS