### PR TITLE
Destroy background music fix

### DIFF
--- a/src/MediaInstance.js
+++ b/src/MediaInstance.js
@@ -317,7 +317,7 @@ export default class HlsInstance {
                 }
                 break;
             case MediaTypes.OTHER:
-                if (this._mountedMediaElement){
+                if (this._mountedMediaElement) {
                     this._mountedMediaElement.src = '';
                 }
                 break;


### PR DESCRIPTION
Origami background music wasn't being destroyed properly.  This was because it is media type OTHER, rather than DASH or HLS, and detachMedia did nothing in that case.
This fixes this by setting media element src to ''.