### PR TITLE
fix no background audio on start

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/romper",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Object Based Media player",
   "main": "dist/romper.js",
   "scripts": {

--- a/src/Player.js
+++ b/src/Player.js
@@ -622,6 +622,7 @@ class Player extends EventEmitter {
             this._narrativeElementTransport.classList.remove('romper-inactive');
             this._logUserInteraction(AnalyticEvents.names.BEHAVIOUR_CONTINUE_BUTTON_CLICKED);
         };
+
         this._startExperienceButton.onclick = buttonClickHandler;
 
         if (options.hide_narrative_buttons) {
@@ -650,7 +651,7 @@ class Player extends EventEmitter {
         this._foregroundMediaElement.pause();
 
         this._logUserInteraction(AnalyticEvents.names.START_BUTTON_CLICKED);
-
+        this._backgroundMediaElement.play();
         this._playPauseButtonClicked();
     }
 


### PR DESCRIPTION
The reason this never worked was that the foreground video listens for a PLAY_PAUSE_BUTTON_CLICKED event which kicks it off. The background renderer had no such handler. 

There was two ways to fix this, one being to make a _handleStartStopButton handler in the background audio renderer, the other was just to do a background media element 'play' once on start. Considering that the background media doesn't really need to care about start/stop, I thought it cleaner to bung this in as a one-liner rather than create a whole new handler in backgroundAudioRenderer and have it only respond once (ie - on experience start).

Open to suggestions though. 