### PR TITLE
Apply media fragment url as well as setting in/out points

### DIFF
--- a/src/renderers/SimpleAVRenderer.js
+++ b/src/renderers/SimpleAVRenderer.js
@@ -308,7 +308,7 @@ export default class SimpleAVRenderer extends BaseRenderer {
             this._videoTrack.default = false;
             videoElement.appendChild(this._videoTrack);
 
-            // Show Subtitles
+            // Show Subtitles.
             this._videoTrack.mode = 'showing';
 
             if (videoElement.textTracks[0]) {


### PR DESCRIPTION
Romper was glitching when using in-points: showing the first frame before jumping to the in-point.  This PR gives the url a media fragment (as well as setting the time) and seems to solve the problem.