### PR TITLE
Fixing bug where choice icons not refreshed on variable change

### DIFF
--- a/src/RenderManager.js
+++ b/src/RenderManager.js
@@ -364,6 +364,7 @@ export default class RenderManager extends EventEmitter {
 
     // show next button, or icons if choice
     _showOnwardIcons() {
+        this._player.clearLinkChoices();
         const next = this._controller.getValidNextSteps();
         if (next) {
             next.then((nextNarrativeElements) => {
@@ -433,6 +434,7 @@ export default class RenderManager extends EventEmitter {
             }
         });
         this._upcomingRenderers.push(upcomingRenderers);
+        this._showOnwardIcons();
     }
 
     _initialise() {


### PR DESCRIPTION
Quick fix to a bug that surfaced when testing complex variables.

Makes sure that the choice icons are properly refreshed when variables change.