### PR TITLE
Do not end mediaInstance when unqueued, so can switch back to it.

### DIFF
--- a/src/playoutEngines/SrcSwitchPlayoutEngine.js
+++ b/src/playoutEngines/SrcSwitchPlayoutEngine.js
@@ -170,7 +170,6 @@ export default class SrcSwitchPlayoutEngine extends BasePlayoutEngine {
             this._cleanUpSubtitles(rendererId);
             this._player.disableSubtitlesControl();
             rendererPlayoutObj.mediaInstance.pause();
-            rendererPlayoutObj.mediaInstance.end();
             super.setPlayoutInactive(rendererId);
             this._player.removeVolumeControl(rendererId);
         }


### PR DESCRIPTION
While using src switching, switching away from a video caused the mediaInstance to end and have the media detached.  This meant that you could not switch back to it.

This removes the end mediaInstance call from unqueuePlayoutEngine so you can switch back. MediaInstance still _seems_ to be cleaned up properly at the end.