### PR TITLE
Seal AFrameRenderer instead of freezing

### DIFF
--- a/src/renderers/AFrameRenderer.js
+++ b/src/renderers/AFrameRenderer.js
@@ -571,6 +571,6 @@ class AFrameRenderer extends EventEmitter {
 }
 
 const instance = new AFrameRenderer();
-Object.freeze(instance);
+Object.seal(instance);
 
 export default instance;


### PR DESCRIPTION
This fixes an issue currently affecting the standalone branch of story former (which uses slightly more up to date version of node & stuff).

When starting up romper for the first time without this fix you'll get:
`TypeError: Cannot assign to read only property '_eventsCount' of object '#<AFrameRenderer>'`

Following the trail down it's because the version of 'events' we have has a special case for one event listener which attempts to mutate the EventEmitter's state.
It fails for AFrameRenderer (an emitter) since it's frozen. 
```js
   // Optimize the case of one listener. Don't need the extra array object.
    existing = events[type] = listener;
    ++target._eventsCount // target is the EventEmitter 
```

Switching to `Object.seal` instead of freeze fixes this.
It allows exiting attributes to be updated, but does not allow adding any new attributes.
Don't think this change breaks anything (but I don't know much about rompers internals).