### PR TITLE
Fix bug where volume did not persist between elements

### DIFF
--- a/src/RenderManager.js
+++ b/src/RenderManager.js
@@ -464,12 +464,6 @@ export default class RenderManager extends EventEmitter {
             }
         }
 
-        // ensure volume persistence
-        Object.keys(this._rendererState.volumes).forEach((label) => {
-            const value = this._rendererState.volumes[label];
-            this._player.setVolumeControlLevel(label, value);
-        });
-
         if (oldRenderer) {
             if (oldRenderer.isVRViewable() && !newRenderer.isVRViewable()) {
                 // exit VR mode if necessary
@@ -496,6 +490,13 @@ export default class RenderManager extends EventEmitter {
         this.refreshOnwardIcons();
 
         newRenderer.willStart();
+
+        // ensure volume persistence
+        Object.keys(this._rendererState.volumes).forEach((label) => {
+            const value = this._rendererState.volumes[label];
+            this._player.setVolumeControlLevel(label, value);
+        });
+
     }
 
     _showBackIcon() {


### PR DESCRIPTION
On changing the NE, the volume was set before starting the element, which meant that the playout engine set the volume on the old media element, not the new one.  Now set volume after willStart