### PR TITLE
Promisify link icon loading so icons only shown after all loaded

### DIFF
--- a/src/Player.js
+++ b/src/Player.js
@@ -1074,11 +1074,6 @@ class Player extends EventEmitter {
         Object.keys(this._choiceIconSet).forEach((id) => {
             promisesArray.push(this._choiceIconSet[id]);
         });
-        Promise.all(promisesArray).then((icons) => {
-            icons.forEach((icon, id) => {
-                this._linkChoice.add(id, icon);
-            });
-        });
         if (activeLinkId) {
             this._linkChoice.setActive(activeLinkId);
         }
@@ -1086,6 +1081,11 @@ class Player extends EventEmitter {
             && !(overlayClass in this._linkChoice.overlay.classList)) {
             this._linkChoice.overlay.classList.add(overlayClass);
         }
+        return Promise.all(promisesArray).then((icons) => {
+            icons.forEach((icon, id) => {
+                this._linkChoice.add(id, icon);
+            });
+        });
     }
 
     getActiveChoiceIcon(): ?HTMLDivElement {

--- a/src/renderers/BaseRenderer.js
+++ b/src/renderers/BaseRenderer.js
@@ -297,8 +297,8 @@ export default class BaseRenderer extends EventEmitter {
                 assetCollectionIds.push(this._representation.asset_collections.icon.active_id);
             }
         }
-        assetCollectionIds.forEach((iconAssetCollection) => {
-            this._fetchAssetCollection(iconAssetCollection)
+        return Promise.all(assetCollectionIds.map((iconAssetCollection) => {
+            return this._fetchAssetCollection(iconAssetCollection)
                 .then((assetCollection) => {
                     if (assetCollection.assets.image_src) {
                         return this._fetchMedia(assetCollection.assets.image_src);
@@ -313,7 +313,7 @@ export default class BaseRenderer extends EventEmitter {
                         this._preloadedIconAssets.push(image);
                     }
                 });
-        });
+        }));
     }
 
     getBehaviourRenderer(behaviourUrn: string): (behaviour: Object, callback: () => mixed) => void {


### PR DESCRIPTION
Instead of creating all icons and showing them when they are loaded, create a set of promises that are resolved when the image element is loaded, and only then show all the icons.

NB. The behaviour assets should be prefetched when the renderer is constructed.  I have added a similar prefetch for icons - the icons for any NE are preloaded when a renderer for that element is created (i.e., in the lookahead stage).  I'm not certain that this will always be early enough though.