### PR TITLE
Do not render question mark if no icon defined

### DIFF
--- a/src/renderers/BaseRenderer.js
+++ b/src/renderers/BaseRenderer.js
@@ -502,27 +502,7 @@ export default class BaseRenderer extends EventEmitter {
                     }
                 });
             }
-            if (iconSpecObject.acId === null && iconSpecObject.iconText === null) {
-                // if not specified - get default icon...
-                iconObjectPromises.push(this._controller
-                    .getRepresentationForNarrativeElementId(choiceNarrativeElementObj.ne.id)
-                    .then((representation) => {
-                        let defaultSrcAcId = null;
-                        if (representation && representation.asset_collections.icon
-                            && representation.asset_collections.icon.default_id) {
-                            defaultSrcAcId = representation.asset_collections.icon.default_id;
-                        }
-                        return Promise.resolve({
-                            choiceId: i,
-                            acId: defaultSrcAcId,
-                            ac: null,
-                            resolvedUrl: null,
-                            targetNarrativeElementId: choiceNarrativeElementObj.targetNeId,
-                        });
-                    }));
-            } else {
-                iconObjectPromises.push(Promise.resolve(iconSpecObject));
-            }
+            iconObjectPromises.push(Promise.resolve(iconSpecObject));
         });
 
         return Promise.all(iconObjectPromises).then((iconSpecObjects) => {
@@ -576,14 +556,16 @@ export default class BaseRenderer extends EventEmitter {
                 iconObject.iconText,
                 `Option ${(iconObject.choiceId + 1)}`,
             );
-        } else {
+        } else if (iconObject.resolvedUrl) {
             icon = this._player.addLinkChoiceControl(
                 targetId,
                 iconObject.resolvedUrl,
                 `Option ${(iconObject.choiceId + 1)}`,
             );
+        } else {
+            logger.warn(`No icon specified for link to ${targetId} - not rendering`);
         }
-        if (iconObject.position && iconObject.position.two_d) {
+        if (icon && iconObject.position && iconObject.position.two_d) {
             const {
                 left,
                 top,


### PR DESCRIPTION
As it says - if the data model specifies show link icons for the representation, but there is no icon defined, either in the behaviour or in the target representation, then do not render an icon.

(The previous behaviour was to render an icon with a default image showing a question mark)

Maybe we need a quick discussion?  Click want this, and it makes sense to me, but losing the question mark could make debugging/drafting an experience trickier (but less so now we can use text for links).