### PR TITLE
Fullscreen icons

### DIFF
--- a/src/Player.js
+++ b/src/Player.js
@@ -1158,10 +1158,15 @@ class Player extends EventEmitter {
         this._numChoices += 1;
         this._linkChoice.overlay.classList.add(`choices-${this._numChoices}`);
 
-        if (this._numChoices >= 4) {
+        if (this._numChoices > 8) {
+            this._linkChoice.overlay.classList.remove('tworow');
+            this._linkChoice.overlay.classList.add('threerow');
+        } else if (this._numChoices >= 4) {
+            this._linkChoice.overlay.classList.remove('threerow');
             this._linkChoice.overlay.classList.add('tworow');
         } else {
             this._linkChoice.overlay.classList.remove('tworow');
+            this._linkChoice.overlay.classList.remove('threerow');
         }
 
         const linkChoiceControl = document.createElement('div');

--- a/src/assets/styles/player.scss
+++ b/src/assets/styles/player.scss
@@ -546,6 +546,10 @@ $romper-hover-text-size: 25px;
         grid-template-rows: 1fr 1fr;
       }
 
+      &.threerow {
+        grid-template-rows: 1fr 1fr 1fr;
+      }
+
       .romper-link-icon-container {
         height: 100%;
         margin: 0;


### PR DESCRIPTION
Add a class for link icons to cover the fullscreen.

Also enables icons to be built in to the media and actual icons to be invisible if we apply following css:
`.fullscreen-icons {
    opacity: 0;
}`

2 rows if >= 4 icons. 