### PR TITLE
Remove Volume button on iOS, it doesn't work anyway

### DIFF
--- a/src/Player.js
+++ b/src/Player.js
@@ -1042,6 +1042,10 @@ class Player extends EventEmitter {
     }
 
     addVolumeControl(id: string, label: string) {
+        if(BrowserUserAgent.iOS()) {
+            return;
+        }
+
         const volumeControl = document.createElement('div');
         volumeControl.classList.add('romper-volume-control');
         volumeControl.classList.add(`romper-volume-label-${label.toLowerCase()}`);


### PR DESCRIPTION
# Details
iOS won't let us control volume so remove the button.

Fixes: https://jira.dev.bbc.co.uk/browse/PRODTOOLS-1997

# PR Checks
(tick as appropriate) 

- [ ] PR has the package.json version bumped 
