### PR TITLE
Controls back when icons disappear

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/storyplayer",
-  "version": "0.3.21",
+  "version": "0.3.22",
   "description": "Object Based Media player",
   "main": "dist/romper.js",
   "scripts": {

--- a/src/renderers/BaseRenderer.js
+++ b/src/renderers/BaseRenderer.js
@@ -761,6 +761,7 @@ export default class BaseRenderer extends EventEmitter {
                 this._hideChoiceIcons(null);
                 // refresh next/prev so user can skip now if necessary
                 this._controller.refreshPlayerNextAndBack();
+                this._player.enableControls();
             }
         } else {
             // or follow link now


### PR DESCRIPTION
# Details
In the case where users only have one chance to choose a link, the transport controls become available again when the choices disappear.

https://jira.dev.bbc.co.uk/browse/PRODTOOLS-2001

# PR Checks
(tick as appropriate) 

- [x] PR has the package.json version bumped 
