### PR TITLE
Make controls 100% width instead of 100vw

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/storyplayer",
-  "version": "0.3.33",
+  "version": "0.3.34",
   "description": "Object Based Media player",
   "main": "dist/romper.js",
   "scripts": {

--- a/src/assets/styles/player.scss
+++ b/src/assets/styles/player.scss
@@ -701,7 +701,7 @@ $romper-hover-text-size: 1.53em;
 @media (min-width: 768px) and (max-width: 1024px) and (orientation: landscape) {
   .romper-player > .romper-gui {
     >.romper-buttons {
-      width: 100vw;
+      width: 100%;
     }
   }
 }
@@ -711,7 +711,7 @@ $romper-hover-text-size: 1.53em;
 @media (min-width: 481px) and (max-width: 767px) {
   .romper-player > .romper-gui {
     >.romper-buttons {
-      width: 100vw;
+      width: 100%;
     }
   }
 }


### PR DESCRIPTION
# Details
This makes the control bar 100% wide instead of 100vw wide, as the player is more than 100vw wide on small devices

# PR Checks
(tick as appropriate) 

- [X] PR has the package.json version bumped 
