### PR TITLE
Hacky check for video stalling at end.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/storyplayer",
-  "version": "0.3.54",
+  "version": "0.3.55",
   "description": "Object Based Media player",
   "main": "dist/romper.js",
   "scripts": {

--- a/src/renderers/SimpleAVRenderer.js
+++ b/src/renderers/SimpleAVRenderer.js
@@ -40,6 +40,8 @@ export default class SimpleAVRenderer extends BaseRenderer {
 
     _outTimeEventListener: Function;
 
+    _testEndStallTimeout: TimeoutID;
+
     _setOutTime: Function;
 
     _setInTime: Function;
@@ -95,6 +97,18 @@ export default class SimpleAVRenderer extends BaseRenderer {
             if (this._outTime > 0 && videoElement.currentTime >= this._outTime) {
                 videoElement.pause();
                 this._endedEventListener();
+            }
+            if (videoElement.currentTime > (videoElement.duration - 1)) {
+                const nowTime = videoElement.currentTime;
+                if (this._playoutEngine.isPlaying() && !this._testEndStallTimeout) {
+                    this._testEndStallTimeout = setTimeout(() => {
+                        if (videoElement.currentTime <= nowTime + 0.5) {
+                            logger.warn('Video end chekcer failed stall test');
+                            clearTimeout(this._testEndStallTimeout);
+                            this._endedEventListener();
+                        }
+                    }, 1000);
+                }
             }
         }
     }


### PR DESCRIPTION
# Details
Tries to avoid getting stuck at the end due to media problems.

When it reaches last second of playback, set a timer for 1s later to see if we have moved on at least 0.5s; if not call end()

# PR Checks
(tick as appropriate) 

- [x] PR has the package.json version bumped 
