### PR TITLE
Fix lookahead bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/storyplayer",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Object Based Media player",
   "main": "dist/romper.js",
   "scripts": {

--- a/src/RenderManager.js
+++ b/src/RenderManager.js
@@ -659,8 +659,8 @@ export default class RenderManager extends EventEmitter {
                                     // need to render description only as placeholder
                                     const dummyRep = {
                                         ...PLACEHOLDER_REPRESENTATION,
-                                        description: narrativeElement.description,
-                                        id: narrativeElement.id,
+                                        description: neObj.description,
+                                        id: neObj.id,
                                     };
                                     return Promise.resolve(dummyRep);
                                 })


### PR DESCRIPTION
# Details
Lookahead was using wrong NE id for dummy representation

# PR Checks
(tick as appropriate) 

- [x] PR has the package.json version bumped 
