### PR TITLE
Properly clear RM event listeners on restart

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/storyplayer",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Object Based Media player",
   "main": "dist/romper.js",
   "scripts": {


### PR DESCRIPTION
# Details
Didn't clear event listeners on RenderManager, so restart created duplicates.  Now clear properly.

Also cleared some eslint warnings :)

# PR Checks
(tick as appropriate) 

- [x] PR has the package.json version bumped 
