### PR TITLE
Maintain view direction between 360 scenes

### DIFF
--- a/src/renderers/ThreeJsBaseRenderer.js
+++ b/src/renderers/ThreeJsBaseRenderer.js
@@ -146,6 +146,9 @@ export default class ThreeJsBaseRenderer extends BaseRenderer {
     }
 
     _createScene() {
+        // maintain view direction
+        this._applyPreviousOrientation();
+
         const target = this._player.mediaTarget;
         logger.info('Starting 3js video scene');
         this._scene = new THREE.Scene();
@@ -184,6 +187,24 @@ export default class ThreeJsBaseRenderer extends BaseRenderer {
             webGlRenderer.render( this._scene, this._camera );
             this._testIfViewingIcon();
         };
+    }
+
+    // retrieve previous lat and long values from the variable store and apply
+    _applyPreviousOrientation() {
+        this._controller.getVariableValue('_threejs_orientation_lon')
+            .then((lon) => {
+                if (lon !== null) {
+                    logger.info(`Maintaining 360 orientation at ${lon} longitude`);
+                    this._view.lon = lon; 
+                }
+            });
+        this._controller.getVariableValue('_threejs_orientation_lat')
+            .then((lat) => { 
+                if (lat !== null) {
+                    logger.info(`Maintaining 360 orientation at ${lat} latitude`);
+                    this._view.lat = lat;
+                }
+            });
     }
 
     _animate() {


### PR DESCRIPTION
# Details
When starting a 360 scene, set the orientation to match what it was previously (if known). 

# PR Checks
(tick as appropriate) 

- [ ] PR has the package.json version bumped 
