### PR TITLE
fix: reduce logger output

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/storyplayer",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Object Based Media player",
   "main": "dist/romper.js",
   "scripts": {

--- a/src/renderers/BaseRenderer.js
+++ b/src/renderers/BaseRenderer.js
@@ -396,9 +396,7 @@ export default class BaseRenderer extends EventEmitter {
         const currentTime = this._timer.getTime();
         let timeBased = false;
         let remainingTime = Infinity;
-        if (duration === Infinity) {
-            logger.warn('getting time data from BaseRenderer without duration');
-        } else {
+        if (duration !== Infinity) {
             timeBased = true;
             remainingTime = duration - currentTime;
         }


### PR DESCRIPTION
# Details
No longer log fact that renderer has infinite duration on every timeupdate

# Jira Ticket
Ticket URL: https://jira.dev.bbc.co.uk/browse/PRODTOOLS-2230

# PR Checks
(tick as appropriate) 

- [x] PR is linked to JIRA ticket
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [x] PR has the package.json version bumped 
