### PR TITLE
fix: remove black flash for vid-img transition on firefox

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/storyplayer",
-  "version": "0.10.10",
+  "version": "0.10.11",
   "description": "Object Based Media player",
   "main": "dist/romper.js",
   "scripts": {

--- a/src/renderers/ImageRenderer.js
+++ b/src/renderers/ImageRenderer.js
@@ -121,7 +121,7 @@ export default class ImageRenderer extends BaseRenderer {
     }
 
     _setVisibility(visible: boolean) {
-        if (this._imageElement) this._imageElement.style.display = visible ? 'initial' : 'none';
+        if (this._imageElement) this._imageElement.style.opacity = visible ? '1' : '0';
     }
 
     destroy() {


### PR DESCRIPTION
# Details
Changes the way images are hidden to prevent the black glitch in Firefox when transitioning from video to image.

# Jira Ticket
Ticket URL: https://jira.dev.bbc.co.uk/browse/PRODTOOLS-2320

# PR Checks
(tick as appropriate) 

- [x] PR is linked to JIRA ticket
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [x] PR has the package.json version bumped 
