### PR TITLE
fix: dont bump up icons in ios fullscreen (now fixed in media area)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/storyplayer",
-  "version": "0.11.27",
+  "version": "0.11.28",
   "description": "Object Based Media player",
   "main": "dist/romper.js",
   "scripts": {

--- a/src/assets/styles/player.scss
+++ b/src/assets/styles/player.scss
@@ -116,14 +116,6 @@ $start-button-size: 15vw;
   justify-content: flex-end;
   position: relative;
 
-  &.ios-fullscreen > .romper-gui {
-    > .romper-buttons,
-    > .romper-buttons-activate-area,
-    > .romper-overlays >.romper-overlay {
-      bottom: 5%;
-    }
-  }
-
   * {
     box-sizing: content-box;
   }
@@ -1616,18 +1608,6 @@ $start-button-size: 15vw;
     background: $black;
     border: 0;
     color: $white;
-  }
-}
-
-@media (orientation: portrait) {
-  .romper-player {
-    &.ios-fullscreen > .romper-gui {
-      > .romper-buttons,
-      > .romper-overlays > .romper-overlay,
-      > .romper-buttons-activate-area {
-        bottom: 20%; // ios fullscreen portrait push buttons up more
-      }
-    }
   }
 }
 


### PR DESCRIPTION
# Details
choices and ui now fixed within media window so no need to bump up ios fullscreen
# Jira Ticket
Ticket URL: 

# PR Checks
(tick as appropriate) 

- [ ] PR is linked to JIRA ticket
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [x] PR has the package.json version bumped 
