### PR TITLE
chore: storyformer auto version bumping when storyplayer is upgraded

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -131,9 +131,8 @@ pipeline {
             sh '''
               yarn add --registry "$artifactory_pull" --dev --ignore-scripts @bbc/storyplayer
               git add package.json yarn.lock
-              git fetch origin
-              git rebase origin/master
               yarn version --patch --message  "chore: Upgrade storyplayer to ${git_version} and version bump to %s"
+              git pull --rebase
               git push origin master --tags
             '''
           }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/storyplayer",
-  "version": "0.11.45",
+  "version": "0.11.46",
   "description": "Object Based Media player",
   "main": "dist/romper.js",
   "scripts": {


### PR DESCRIPTION
# Details
Brief description of what this PR does. 

# Jira Ticket
Ticket URL: 

# PR Checks
(tick as appropriate) 

- [ ] PR is linked to JIRA ticket
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [x] PR has the package.json version bumped 
