### PR TITLE
feature: enable userids to persist across sessions

### DIFF
--- a/src/AnalyticsHandler.js
+++ b/src/AnalyticsHandler.js
@@ -1,9 +1,12 @@
 import AnalyticEvents from './AnalyticEvents';
 
+const uuidv4 = require('uuid/v4');
+
 export default class AnalyticsHandler {
     constructor(analytics, controller) {
         this._analytics = analytics;
         this._controller = controller;
+        this.userid = uuidv4();
 
         this._segmentSummaryData = {};
         this._lastpausedTime = Date.now();
@@ -23,7 +26,7 @@ export default class AnalyticsHandler {
         this._analytics(appendedPayload);
     }
 
-    // add current NE and Representation ids
+    // add user id, current NE and Representation ids
     _enhanceAnalytics(logData) {
         let repId = logData.current_representation;
         const renderer = this._controller.getCurrentRenderer();
@@ -39,9 +42,15 @@ export default class AnalyticsHandler {
             ...logData,
             current_narrative_element: neId,
             current_representation: repId,
+            userid: this.userid,
         };
 
         return appendedData;
+    }
+
+    // override automatically generated uuid, perhaps with one from saved state
+    setUserId(uuid) {
+        this.userid = uuid;
     }
      
     _sumpausedTime() {

--- a/src/Controller.js
+++ b/src/Controller.js
@@ -318,6 +318,18 @@ export default class Controller extends EventEmitter {
 
     _createSessionManager(storyId: string) {
         this._sessionManager = new SessionManager(storyId);
+        if (this.getSessionState() !== SESSION_STATE.NEW) {
+            this._sessionManager.fetchUserId()
+                .then(id => {
+                    if (id) {
+                        this._analyticsHandler.setUserId(id);
+                    } else {
+                        this._sessionManager.setUserId(this._analyticsHandler.userid);
+                    }
+                });
+        } else {
+            this._sessionManager.setUserId(this._analyticsHandler.userid);
+        }
     }
 
     getCurrentRenderer(): ?BaseRenderer {

--- a/src/SessionManager.js
+++ b/src/SessionManager.js
@@ -112,6 +112,21 @@ export default class SessionManager extends EventEmitter {
         });
     }
 
+    fetchUserId(): Promise<?[string]> {
+        return this.fetchExistingSessionState().then(resumeState => {
+            if (!resumeState) return null;
+            return resumeState.userid;
+        });
+    }
+    
+    setUserId(userid: string) {
+        this.fetchExistingSessionState().then(resumeState => {
+            // eslint-disable-next-line no-param-reassign
+            resumeState.userid = userid;
+            localStorage.setItem(this._storyId, JSON.stringify(resumeState));
+        });
+    }
+
     setSessionState(state: string) {
         this.sessionState = SESSION_STATE[state];
     }


### PR DESCRIPTION
# Details
StoryPlayer now generates an analytics userid and sends it with the analytics log data.  This userid is stored in and recovered from local storage, allowing the same userid to be sent across multiple sessions with an experience (different ids will be used per experience) and will ultimately help us understand how audiences split viewing across sessions.

Note that this will require changes to whatever is passing StoryPlayer the analytics logger (e.g., StoryPlayerHarness), but these changes will not break that connection.

# Jira Ticket
Ticket URL: https://jira.dev.bbc.co.uk/browse/PRODTOOLS-2750

# PR Checks
(tick as appropriate) 

- [x] PR is linked to JIRA ticket
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [ ] PR has the package.json version bumped 
