### PR TITLE
fix: check for timedEvents when set time

### DIFF
--- a/src/TimeManager.js
+++ b/src/TimeManager.js
@@ -17,7 +17,7 @@ export default class TimeManager extends EventEmitter {
 
     _syncing: boolean;
 
-    _debug: false;
+    _debug: boolean;
 
     constructor() {
         super();
@@ -36,7 +36,7 @@ export default class TimeManager extends EventEmitter {
                 this._timeElapsed += TIMER_INTERVAL/1000;
                 this._testForEvents();
             }
-            if (this._debug && this._timeElapsed % 200 === 0) {
+            if (this._debug && this._timeElapsed > 0 && this._timeElapsed % 200 === 0) {
                 logger.info('timer', this._timeElapsed);
             }
         }, TIMER_INTERVAL);

--- a/src/renderers/BaseRenderer.js
+++ b/src/renderers/BaseRenderer.js
@@ -523,9 +523,12 @@ export default class BaseRenderer extends EventEmitter {
                 this._playoutEngine.off(this._rendererId,'timeupdate', sync);
             }
         };
-        this._timer.setSyncing(true);
-        this._playoutEngine.on(this._rendererId,'timeupdate', sync);
-        this._playoutEngine.setCurrentTime(this._rendererId, targetTime);
+        // only try to sync if playout engine has time
+        if (this._playoutEngine.getCurrentTime(this._rendererId)) {
+            this._timer.setSyncing(true);
+            this._playoutEngine.on(this._rendererId,'timeupdate', sync);
+            this._playoutEngine.setCurrentTime(this._rendererId, targetTime);
+        }
     }
 
     _togglePause() {


### PR DESCRIPTION
# Details
Means timed events still happen even when timer is only running through setTime syncing with media

# Jira Ticket
Ticket URL: 

# PR Checks
(tick as appropriate) 

- [ ] PR is linked to JIRA ticket
- [ ] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [ ] PR has the package.json version bumped 
