### PR TITLE
fix: show next button on final element if infinite

### DIFF
--- a/src/RenderManager.js
+++ b/src/RenderManager.js
@@ -663,7 +663,10 @@ export default class RenderManager extends EventEmitter {
                 return this._controller.getValidNextSteps()
                     .then((nextSteps) => {
                         const hasNext = nextSteps.length > 0;
-                        this._player.setNextAvailable(hasNext);
+                        const isInUntimedRepresentation = 
+                            this._currentRenderer
+                            && this._currentRenderer.getDuration() === Infinity;
+                        this._player.setNextAvailable(hasNext || isInUntimedRepresentation);
                     })
                     .catch((err) => {
                         logger.error('Could not get valid next steps to set next button availability', err); // eslint-disable-line max-len


### PR DESCRIPTION
# Details
Normally the next button is disabled if there are no further elements.  If the last element is a video (or timed in any way), when it ends, the story will finish and show the restart screen.  If the last element is untimed, there is no way to go anywhere - you just see the last element.  This change means that in the latter situation the next button is available; clicking it will end the story and take you to restart.

NEEDS DISCUSSION!

# Jira Ticket
Ticket URL: https://jira.dev.bbc.co.uk/browse/PRODTOOLS-3145

# PR Checks
(tick as appropriate) 

- [x] PR is linked to JIRA ticket
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [ ] PR has the package.json version bumped 
