### PR TITLE
fix allow you to get media element for SMP

### DIFF
--- a/src/playoutEngines/SMPPlayoutEngine.js
+++ b/src/playoutEngines/SMPPlayoutEngine.js
@@ -549,8 +549,9 @@ class SMPPlayoutEngine extends BasePlayoutEngine {
         return false
     }
 
+    // eslint-disable-next-line no-unused-vars
     _getMediaElement(rendererId: string): ?HTMLMediaElement {
-        throw new Error("SMP RenderEngine doesn't allow access to HTML Media Element");
+        return this._smpPlayerInterface.requestVideoElement(true);
     }
 
     setLoopAttribute(rendererId: string, loop: ?boolean) {


### PR DESCRIPTION
# Details
Fixes bug when trying to set loop attribute, so we can play Mike's stories https://storyplayer.rd.int.tools.bbc.co.uk/private/7b58b68b-3681-4c09-a323-23e091a38ca2?player=SMP

# Jira Ticket
Ticket URL: https://jira.dev.bbc.co.uk/browse/PRODTOOLS-3156

# PR Checks
(tick as appropriate) 

- [x] PR is linked to JIRA ticket
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [ ] PR has the package.json version bumped 
