### PR TITLE
fix: external links work with touch and only one click

### DIFF
--- a/src/assets/styles/player.scss
+++ b/src/assets/styles/player.scss
@@ -1094,12 +1094,6 @@ $start-button-size: 15vw;
     }
   }
 
-  .romper-link-out {
-    &:hover {
-      text-decoration: underline;
-    }
-  }
-
   &.text-overlay {
     align-items: center;
     display: flex;

--- a/src/behaviours/LinkOutBehaviourHelper.js
+++ b/src/behaviours/LinkOutBehaviourHelper.js
@@ -20,7 +20,7 @@ const setPosition = (modalElement, behaviour) => {
 const createLink = (behaviour) => {
     const linkText = behaviour.link_text;
     let linkUrl = behaviour.link_url;
-    const linkElement = createElementWithClass('span', null, ['romper-link-out']);
+    const linkElement = document.createElement('a');
 
     // if the link isn't absolute ie http or https we are going to assume authors want 
     // https absolute links
@@ -65,7 +65,7 @@ export const renderLinkoutPopup = (behaviour, target, callback, analytics) => {
     modalElement.appendChild(closeButton);
 
     const link = createLink(behaviour);
-    const linkClickAction = () => {
+    const linkClickAction = (e) => {
         analytics({
             type: AnalyticEvents.types.USER_ACTION,
             name: AnalyticEvents.names.OUTWARD_LINK_CLICKED,
@@ -73,6 +73,7 @@ export const renderLinkoutPopup = (behaviour, target, callback, analytics) => {
             to: behaviour.link_url,
         });
         window.open(link.href, '_blank');
+        e.preventDefault();
     };
     link.addEventListener('touchend', handleButtonTouchEvent(linkClickAction));
     link.onclick = linkClickAction;


### PR DESCRIPTION
# Details
External links were broken in 2 ways:
* did not work on touch devices
* needed two clicks on desktops

This fixes both.  The fix is a bit messy, due to the way in which events are handled triggering transport controls, etc.  The link is not an `<a>` element, but a `<span>` for which touch and click handling is done manually.  This ensures that the link is triggered first time by both touch and mouse, the analytics are collected and only one action is triggered.  Tested with both STANDARD and SMP players on https://storyplayer.rd.dev.tools.bbc.co.uk/private/95cf1950-4079-408a-909b-3acaf7427d43

# Jira Ticket
Ticket URL: https://jira.dev.bbc.co.uk/browse/PRODTOOLS-3168

# PR Checks
(tick as appropriate) 

- [x] PR is linked to JIRA ticket
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [x] PR has the package.json version bumped 
