### PR TITLE
fix: pause properly with trimmed media

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/storyplayer",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "StoryPlayer - reference player for BBC Research & Development's object-based media schema (https://www.npmjs.com/package/@bbc/object-based-media-schema)",
   "main": "dist/storyplayer.js",
   "keywords": [

--- a/src/gui/Player.js
+++ b/src/gui/Player.js
@@ -1463,6 +1463,13 @@ class Player extends EventEmitter {
     }
 
     exitCompleteBehaviourPhase() {
+        // with trimmed media we sometimes need to force the
+        // playout engine to pause at the end
+        // if this has happened, get it going again
+        if (this._currentRenderer.forcedPauseForTrimmedMedia) {
+            this.playoutEngine.play();
+            this._currentRenderer.forcedPauseForTrimmedMedia = false;
+        }
         this._controls.enableSeekBack();
     }
 

--- a/src/renderers/BaseRenderer.js
+++ b/src/renderers/BaseRenderer.js
@@ -135,6 +135,8 @@ export default class BaseRenderer extends EventEmitter {
 
     phase: string;
 
+    forcedPauseForTrimmedMedia: Boolean;
+
     /**
      * Load an particular representation. This should not actually render anything until start()
      * is called, as this could be constructed in advance as part of pre-loading.
@@ -222,6 +224,8 @@ export default class BaseRenderer extends EventEmitter {
 
         this._serviceTimedEvents = this._serviceTimedEvents.bind(this);
         this._timedEvents = {};
+
+        this.forcedPauseForTrimmedMedia = false;
     }
 
     _serviceTimedEvents() {
@@ -677,6 +681,15 @@ export default class BaseRenderer extends EventEmitter {
         }
         logger.warn(`Unable to handle behaviour of type &{behaviourUrn}`);
         return null;
+    }
+
+    hasEndPauseBehaviour(): boolean {
+        if (this._representation.behaviours?.completed) {
+            const endMatches = this._representation.behaviours.completed.filter(behave =>
+                behave.type === 'urn:x-object-based-media:representation-behaviour:pause/v1.0'); // eslint-disable-line max-len
+            return (endMatches.length > 0);
+        }
+        return false;
     }
 
     hasShowIconBehaviour(): boolean {
@@ -1161,11 +1174,8 @@ export default class BaseRenderer extends EventEmitter {
     // user has made a choice of link to follow - do it
     _followLink(narrativeElementId: string, behaviourId: string) {
         if (this.phase === RENDERER_PHASES.WAITING) {
+            // was paused for user choice: done WAITING, now FINISHED 
             this._setPhase(RENDERER_PHASES.MEDIA_FINISHED);
-            // paused for user choice, restart once icons gone
-            if (!this._playoutEngine.isPlaying()) {
-                setTimeout(() => this.play(), LINK_FADE_TIME);
-            }
         } else if (!this._playoutEngine.isPlaying()) {
             // if they are paused, then clicking a choice should restart immediately
             this.play();

--- a/src/renderers/BaseTimedMediaRenderer.js
+++ b/src/renderers/BaseTimedMediaRenderer.js
@@ -146,7 +146,7 @@ export default class BaseTimedMediaRenderer extends BaseRenderer {
             (isLooping && this._accumulatedMediaTime >= duration)
         ) {
             // Some players fallback to first frame--force showing ending frame.
-            this._playoutEngine.setCurrentTime(this._rendererId, duration-0.1);
+            this._playoutEngine.setCurrentTime(this._rendererId, this._inTime + duration - 0.1);
 
             // Seeking past end on some players will cause end to trigger even
             // when paused. Cycle Play-Pause for consistent player state.
@@ -157,8 +157,16 @@ export default class BaseTimedMediaRenderer extends BaseRenderer {
                 if (this.phase === RENDERER_PHASES.WAITING) {
                     // if we have non-looping trimmed media, and are waiting
                     // for user to select link, we need to pause
+                    this.forcedPauseForTrimmedMedia = true;
                     this._playoutEngine.pause();
                 } else {
+                    if (this.hasEndPauseBehaviour() && this._outTime > 0) {
+                        // we have reached the out point, but there is a pause behaviour
+                        // so we must tell the player to pause, and set a flag so we can
+                        // restart when pause done
+                        this.forcedPauseForTrimmedMedia = true;
+                        this._playoutEngine.pause();
+                    }
                     this._setPhase(RENDERER_PHASES.MEDIA_FINISHED);
                 }
                 clearInterval(this._inspectMediaPlaybackInterval);


### PR DESCRIPTION
# Details
There was a bug where trimmed media continued playing during an end pause behaviour.  This is a fix. 

# Ticket / issue URL
Ticket / issue URL: https://jira.dev.bbc.co.uk/browse/PRODTOOLS-3359

# PR Checks
(tick as appropriate) 

- [x] PR is linked to ticket / issue
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [ ] PR has the package.json version bumped 
