### PR TITLE
chore: update node version for Jenkins builds

### DIFF
--- a/.jenkins/Dockerfile
+++ b/.jenkins/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.20
+FROM node:12.18
 
 RUN apt-get -y update && apt-get -y install netcat-openbsd
 


### PR DESCRIPTION
# Details
Allows the Docker process for Jenkins to use a more recent version of node, fixing a build issue and slightly future proofing it. 

# Ticket / issue URL
Ticket / issue URL: 

# PR Checks
(tick as appropriate) 

- [ ] PR is linked to ticket / issue
- [ ] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [ ] PR has the package.json version bumped 
