### PR TITLE
fix: do not delete renderer that is in use

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/storyplayer",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "StoryPlayer - reference player for BBC Research & Development's object-based media schema (https://www.npmjs.com/package/@bbc/object-based-media-schema)",
   "main": "dist/storyplayer.js",
   "keywords": [

--- a/src/RenderManager.js
+++ b/src/RenderManager.js
@@ -519,10 +519,16 @@ export default class RenderManager extends EventEmitter {
     cleanupActiveRenderers(narrativeElement: NarrativeElement, allIds: string[]) {
         Object.keys(this._activeRenderers)
             .filter(neid => allIds.indexOf(neid) === -1)
+            .filter(neid => {
+                // make sure we aren't deleting current renderer
+                return (this._currentNarrativeElement === undefined) || 
+                    (neid !== this._currentNarrativeElement.id);
+            })
             .forEach((neid) => {
                 if (narrativeElement.id !== neid) {
                     this._activeRenderers[neid].destroy();
                 }
+                logger.info(`Deleting renderer for NE ${neid}`);
                 delete this._activeRenderers[neid];
             });
     }
@@ -852,6 +858,7 @@ export default class RenderManager extends EventEmitter {
             if (this._currentRenderer && this._currentNarrativeElement) {
                 // add current neid
                 allIds.push(this._currentNarrativeElement.id);
+                allIds.push(narrativeElement.id);
             }
 
             // get renderers for all nes in the list


### PR DESCRIPTION
# Details
Adds an additional check to ensure we do not delete the current renderer when tidying unused ones up.

# Ticket / issue URL
Ticket / issue URL: https://jira.dev.bbc.co.uk/browse/PRODTOOLS-3418

# PR Checks
(tick as appropriate) 

- [x] PR is linked to ticket / issue
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [x] PR has the package.json version bumped 
