### PR TITLE
fix: allow any user to write to jenkins user home dir within the container

### DIFF
--- a/.jenkins/Dockerfile
+++ b/.jenkins/Dockerfile
@@ -3,6 +3,8 @@ FROM node:12.18
 RUN apt-get -y update && apt-get -y install netcat-openbsd
 
 ENV HOME /var/tmp/jenkins
+RUN chmod -R a+rw /var/tmp/jenkins
+
 RUN useradd -u 997 -md $HOME jenkins
 USER jenkins
 

--- a/.jenkins/Dockerfile
+++ b/.jenkins/Dockerfile
@@ -3,9 +3,9 @@ FROM node:12.18
 RUN apt-get -y update && apt-get -y install netcat-openbsd
 
 ENV HOME /var/tmp/jenkins
-RUN chmod -R a+rw /var/tmp/jenkins
 
 RUN useradd -u 997 -md $HOME jenkins
+RUN chmod -R a+rw /var/tmp/jenkins
 USER jenkins
 
 RUN mkdir $HOME/.ssh


### PR DESCRIPTION
# Details
Sets `/var/tmp/jenkins` to be globally read/write, allowing the user with id 999 to write to it

# Ticket / issue URL
Ticket / issue URL:  https://jira.dev.bbc.co.uk/browse/PRODTOOLS-3422

# PR Checks
(tick as appropriate) 

- [x] PR is linked to ticket / issue
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [ ] PR has the package.json version bumped 
