### PR TITLE
feat: enable html tags in text overlay behaviours, except script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/storyplayer",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "StoryPlayer - reference player for BBC Research & Development's object-based media schema (https://www.npmjs.com/package/@bbc/object-based-media-schema)",
   "main": "dist/storyplayer.js",
   "keywords": [

--- a/src/behaviours/TextOverlayBehaviourHelper.js
+++ b/src/behaviours/TextOverlayBehaviourHelper.js
@@ -1,6 +1,7 @@
 // not a behaviour in itself, just helps, to keep BaseRenderer Clean
 import { setDefinedPosition, createContainer } from './ModalHelper';
 import { replaceEscapedVariables } from '../utils';
+import logger from '../logger';
 
 /* eslint-disable no-param-reassign */
 const setPosition = (modalElement, behaviour) => {
@@ -14,11 +15,6 @@ const setPosition = (modalElement, behaviour) => {
     }
 };
 /* eslint-enable no-param-reassign */
-
-// remove any script elements from a Text overlay
-const stripScripts = (htmlText) => {
-    return htmlText.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, "");
-}
 
 // eslint-disable-next-line import/prefer-default-export
 export const renderTextOverlay = (behaviour, target, callback, controller) => {
@@ -44,7 +40,14 @@ export const renderTextOverlay = (behaviour, target, callback, controller) => {
     const sentenceDiv = document.createElement('div');
     replaceEscapedVariables(behaviour.text, controller)
         .then((newText) => {
-            sentenceDiv.innerHTML = stripScripts(newText);    
+            const contentEl = document.createElement('div');
+            contentEl.innerHTML = newText.trim();
+            const scripts = contentEl.getElementsByTagName('script');
+            scripts.forEach(s => {
+                logger.warn(`removing script element from text overlay behaviour ${behaviour.id}`);
+                s.remove();
+            });
+            sentenceDiv.appendChild(contentEl);
         });
     modalElement.appendChild(sentenceDiv);
     callback();

--- a/src/behaviours/TextOverlayBehaviourHelper.js
+++ b/src/behaviours/TextOverlayBehaviourHelper.js
@@ -15,6 +15,10 @@ const setPosition = (modalElement, behaviour) => {
 };
 /* eslint-enable no-param-reassign */
 
+// remove any script elements from a Text overlay
+const stripScripts = (htmlText) => {
+    return htmlText.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, "");
+}
 
 // eslint-disable-next-line import/prefer-default-export
 export const renderTextOverlay = (behaviour, target, callback, controller) => {
@@ -40,7 +44,7 @@ export const renderTextOverlay = (behaviour, target, callback, controller) => {
     const sentenceDiv = document.createElement('div');
     replaceEscapedVariables(behaviour.text, controller)
         .then((newText) => {
-            sentenceDiv.textContent = newText;    
+            sentenceDiv.innerHTML = stripScripts(newText);    
         });
     modalElement.appendChild(sentenceDiv);
     callback();

--- a/src/behaviours/TextOverlayBehaviourHelper.js
+++ b/src/behaviours/TextOverlayBehaviourHelper.js
@@ -1,4 +1,4 @@
-// not a behaviour in itself, just helps, to keep BaseRenderer Clean
+// not a behaviour in itself, just helps to keep BaseRenderer Clean
 import { setDefinedPosition, createContainer } from './ModalHelper';
 import { replaceEscapedVariables } from '../utils';
 import logger from '../logger';


### PR DESCRIPTION
# Details
Allows the string for a text overlay behaviour to be HTML and to render it, although `<script>` tags and their content should be stripped.  This should allow much more flexibilty - new lines, headings, bold, better styling, etc.

# Ticket / issue URL
Ticket / issue URL: https://jira.dev.bbc.co.uk/browse/PRODTOOLS-3449

# PR Checks
(tick as appropriate) 

- [x] PR is linked to ticket / issue
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [x] PR has the package.json version bumped 
