### PR TITLE
fix: only render choice focus outlines when keyboard is active

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/storyplayer",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "StoryPlayer - reference player for BBC Research & Development's object-based media schema (https://www.npmjs.com/package/@bbc/object-based-media-schema)",
   "main": "dist/storyplayer.js",
   "keywords": [

--- a/src/assets/styles/player.scss
+++ b/src/assets/styles/player.scss
@@ -772,7 +772,7 @@ $start-button-size: 15vw;
       width: calc(100% - #{(2 * $romper-button-border)});
 
       &:focus {
-        border: 2px solid $backing-colour;
+        border: 0;
         outline: none;
       }
     }
@@ -984,6 +984,14 @@ $start-button-size: 15vw;
       .romper-link-choice-overlay {
         bottom: 8em;
         transition: all 0.5s ease;
+      }
+    }
+
+    &.keyboard-active {
+      .romper-link-control {
+        &:focus {
+          border: 2px solid $backing-colour;
+        }
       }
     }
   }

--- a/src/gui/Player.js
+++ b/src/gui/Player.js
@@ -425,6 +425,16 @@ class Player extends EventEmitter {
                 this._visibleChoices[keyNumber].dispatchEvent(newMouseEvent, true);
             }
         }
+
+        if(!this._keyboardActiveTimeout) {
+            this._overlaysElement.classList.add('keyboard-active');
+        } else {
+            clearTimeout(this._keyboardActiveTimeout);
+        }
+        this._keyboardActiveTimeout = setTimeout(() => {
+            this._overlaysElement.classList.remove('keyboard-active');
+            this._keyboardActiveTimeout = undefined;
+        }, 2000);
     }
 
     setCurrentRenderer(renderer: BaseRenderer) {


### PR DESCRIPTION
# Details
Does not highlight focused choice by default; highlighting only appears when keyboard is used, and disappears after 2s of keyboard inactivity.

# Ticket / issue URL
Ticket / issue URL: https://jira.dev.bbc.co.uk/browse/PRODTOOLS-3445

# PR Checks
(tick as appropriate) 

- [x] PR is linked to ticket / issue
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [x] PR has the package.json version bumped 
