### PR TITLE
fix: add extra pause for SMP after started behaviours

### DIFF
--- a/src/behaviours/BehaviourRunner.js
+++ b/src/behaviours/BehaviourRunner.js
@@ -4,6 +4,7 @@ import BehaviourFactory from "./BehaviourFactory";
 import BaseRenderer from '../renderers/BaseRenderer';
 import type { RendererEvent } from '../renderers/RendererEvents';
 import type { BehaviourTiming } from './BehaviourTimings';
+import SMPPlayoutEngine from "../playoutEngines/SMPPlayoutEngine";
 
 export default class BehaviourRunner {
     behaviourDefinitions: Object;
@@ -81,7 +82,14 @@ export default class BehaviourRunner {
         }
 
         if (this.eventCounters[event] === 0) {
-            this.baseRenderer.emit(completionEvent);
+            if (event === 'started' && this.baseRenderer._player.playoutEngine instanceof SMPPlayoutEngine) {
+                // add an extra bit of delay in case events complete in 0 time
+                // (in that case, SMP gets spammed by show and wait message then play message
+                // almost at once, and falls over)
+                setTimeout(() => this.baseRenderer.emit(completionEvent), 100);
+            } else {
+                this.baseRenderer.emit(completionEvent);
+            }
         }
     }
 }

--- a/src/behaviours/VariableManipulateBehaviour.js
+++ b/src/behaviours/VariableManipulateBehaviour.js
@@ -23,7 +23,7 @@ export default class VariableManipulateBehaviour extends BaseBehaviour {
             controller.getVariableValue(interestingVar)
                 .catch(() => null)
                 .then(value => ({ key: interestingVar, value })))
-            )
+        )
             .then(convertDotNotationToNestedObjects)
             .then((resolvedVars) => {
                 const output = JsonLogic.apply(operation, resolvedVars);

--- a/src/behaviours/VariableManipulateBehaviour.js
+++ b/src/behaviours/VariableManipulateBehaviour.js
@@ -23,7 +23,7 @@ export default class VariableManipulateBehaviour extends BaseBehaviour {
             controller.getVariableValue(interestingVar)
                 .catch(() => null)
                 .then(value => ({ key: interestingVar, value })))
-        )
+            )
             .then(convertDotNotationToNestedObjects)
             .then((resolvedVars) => {
                 const output = JsonLogic.apply(operation, resolvedVars);


### PR DESCRIPTION
# Details
SMP player was crashing with a manipulate variable behaviour as a STARTED behaviour.  This was because when starting to run STARTED behaviours, the player sets up playback in a paused state, so effects (pauses, image overlays,...) can be seen over the start of the video; once the behaviours are complete, playback starts.  However, variable manipulation completes in essentially zero time, and the SMP player falls over when we get it into paused visible state then immediately try to play.

This "fix" puts a brief (100ms) pause in between STARTED events completing and emitting the event that informs the RenderManager of this, in the case of SMP playout, which is sufficient (under my tests!) for the SMP to cope.

Test story: two node story playing PIDs with a range variable, and a manipulation applied to the variable at the start of node 2. Playback in SPH

# Ticket / issue URL
Ticket / issue URL: https://jira.dev.bbc.co.uk/browse/PRODTOOLS-3365

# PR Checks
(tick as appropriate) 

- [x] PR is linked to ticket / issue
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [ ] PR has the package.json version bumped 
