### PR TITLE
fix: remove unnecessary check on jsonlogic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/storyplayer",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "StoryPlayer - reference player for BBC Research & Development's object-based media schema (https://www.npmjs.com/package/@bbc/object-based-media-schema)",
   "main": "dist/storyplayer.js",
   "keywords": [

--- a/src/behaviours/VariableManipulateBehaviour.js
+++ b/src/behaviours/VariableManipulateBehaviour.js
@@ -27,7 +27,7 @@ export default class VariableManipulateBehaviour extends BaseBehaviour {
             .then(convertDotNotationToNestedObjects)
             .then((resolvedVars) => {
                 const output = JsonLogic.apply(operation, resolvedVars);
-                logger.info(`variable manipluated: ${targetVariable} set to ${output}`);
+                logger.info(`variable manipulated: ${targetVariable} set to ${output}`);
                 controller.setVariableValue(targetVariable, output);
                 this._handleDone();
             }).catch(() => {

--- a/src/behaviours/VariableManipulateBehaviour.js
+++ b/src/behaviours/VariableManipulateBehaviour.js
@@ -27,12 +27,8 @@ export default class VariableManipulateBehaviour extends BaseBehaviour {
             .then(convertDotNotationToNestedObjects)
             .then((resolvedVars) => {
                 const output = JsonLogic.apply(operation, resolvedVars);
-                if (output) {
-                    logger.info(`variable manipluated: ${targetVariable} set to ${output}`);
-                    controller.setVariableValue(targetVariable, output);
-                } else {
-                    logger.warn('variable manipulation operation failed');
-                }
+                logger.info(`variable manipluated: ${targetVariable} set to ${output}`);
+                controller.setVariableValue(targetVariable, output);
                 this._handleDone();
             }).catch(() => {
                 logger.warn('variable manipulation operation failed');


### PR DESCRIPTION
# Details
Boolean manipulation was failing because we check the truthiness of a jsonlogic operation.  This is unnecessary as json logic throws an error if the operation expression is invalid.

# Ticket / issue URL
Ticket / issue URL: https://jira.dev.bbc.co.uk/browse/PRODTOOLS-3455

# PR Checks
(tick as appropriate) 

- [x] PR is linked to ticket / issue
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [ ] PR has the package.json version bumped 
