### PR TITLE
fix: sets z indices so links above other overlays

### DIFF
--- a/src/assets/styles/player.scss
+++ b/src/assets/styles/player.scss
@@ -701,7 +701,7 @@ $start-button-size: 15vw;
     pointer-events: none;
     position: absolute;
     width: 80%;
-    z-index: 15;
+    z-index: 16;
 
     &.fullscreen-choice-icons,
     &.fullscreen-icons {
@@ -1431,7 +1431,7 @@ $start-button-size: 15vw;
   position: absolute;
   top: 20px;
   width: 80%;
-  z-index: 16;
+  z-index: 17;
 
   &.show {
     display: initial;


### PR DESCRIPTION
# Details
Map overlays (and other behaviours) and link choices can be added in different orders depending on circumstances.  This sets the z-indices so that link choices are always on top.

# Ticket / issue URL
Ticket / issue URL: 

# PR Checks
(tick as appropriate) 

- [ ] PR is linked to ticket / issue
- [ ] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [ ] PR has the package.json version bumped 
