### PR TITLE
fix: uses credentials when resolving media

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/storyplayer",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "StoryPlayer - reference player for BBC Research & Development's object-based media schema (https://www.npmjs.com/package/@bbc/object-based-media-schema)",
   "main": "dist/storyplayer.js",
   "keywords": [

--- a/src/renderers/BackgroundAudioRenderer.js
+++ b/src/renderers/BackgroundAudioRenderer.js
@@ -160,6 +160,7 @@ export default class BackgroundAudioRenderer extends BackgroundRenderer {
                 mediaFormat: MediaFormats.getFormat(),
                 mediaType: AUDIO,
                 returnPid: false,
+                includeCredentials: true,
             })
             if (this.phase !== RENDERER_PHASES.CONSTRUCTING) {
                 logger.warn('trying to populate audio element that has been destroyed');

--- a/src/renderers/BaseTimedMediaRenderer.js
+++ b/src/renderers/BaseTimedMediaRenderer.js
@@ -203,10 +203,10 @@ export default class BaseTimedMediaRenderer extends BaseRenderer {
                 default:
                     throw new Error("Invalid MDIA_TYPE")
                 }
-                const options = { mediaFormat: MediaFormats.getFormat(), mediaType };
+                const options = { mediaFormat: MediaFormats.getFormat(), mediaType, includeCredentials: true };
                 const mediaUrl = await this._fetchMedia(fg.assets[assetKey], options);
                 if (fg.assets[subtitleKey]) {
-                    const subsUrl = await this._fetchMedia(fg.assets[subtitleKey]);
+                    const subsUrl = await this._fetchMedia(fg.assets[subtitleKey], { includeCredentials: true });
                     mediaObj.subs_url = subsUrl
                 }
                 if (this._destroyed) {

--- a/src/renderers/ImageRenderer.js
+++ b/src/renderers/ImageRenderer.js
@@ -123,7 +123,7 @@ export default class ImageRenderer extends BaseTimedIntervalRenderer {
             );
             if (fg.assets.image_src) {
                 try {
-                    const mediaUrl = await this._fetchMedia(fg.assets.image_src);
+                    const mediaUrl = await this._fetchMedia(fg.assets.image_src, { includeCredentials: true });
                     logger.info(`FETCHED FROM MS MEDIA! ${mediaUrl}`);
                     this._imageElement.src = mediaUrl;
                 }

--- a/src/renderers/SimpleAudioRenderer.js
+++ b/src/renderers/SimpleAudioRenderer.js
@@ -33,7 +33,7 @@ export default class SimpleAudioRenderer extends BaseTimedMediaRenderer {
                 const assetCollectionId = this._representation.asset_collections.background_image;
                 const image = await this._fetchAssetCollection(assetCollectionId);
                 if (image.assets.image_src) {
-                    const imageUrl = await this._fetchMedia(image.assets.image_src);
+                    const imageUrl = await this._fetchMedia(image.assets.image_src, { includeCredentials: true });
                     this._backgroundImage = document.createElement('img');
                     this._backgroundImage.setAttribute('draggable', 'false');
                     this._backgroundImage.className = 'romper-render-image notInteractiveContent noselect';

--- a/src/renderers/SimpleTextRenderer.js
+++ b/src/renderers/SimpleTextRenderer.js
@@ -151,7 +151,7 @@ export default class SimpleTextRenderer extends BaseTimedIntervalRenderer {
             return this._fetchAssetCollection(this._representation.asset_collections.foreground_id)
                 .then((fg) => {
                     if (fg.assets.text_src) {
-                        return this._fetchMedia(fg.assets.text_src)
+                        return this._fetchMedia(fg.assets.text_src, { includeCredentials: true })
                             .then((textFileUrl) => {
                                 this._fetchTextContent(textFileUrl);
                             });

--- a/src/renderers/StoryIconRenderer.js
+++ b/src/renderers/StoryIconRenderer.js
@@ -147,7 +147,7 @@ export default class StoryIconRenderer extends EventEmitter {
             const resolvePromises = [];
             iconAssets.forEach((assetUrl) => {
                 if (assetUrl && assetUrl.assets.image_src) {
-                    resolvePromises.push(this._fetchMedia(assetUrl.assets.image_src));
+                    resolvePromises.push(this._fetchMedia(assetUrl.assets.image_src, { includeCredentials: true }));
                 } else {
                     resolvePromises.push(Promise.resolve(null));
                 }

--- a/src/renderers/SwitchableRenderer.js
+++ b/src/renderers/SwitchableRenderer.js
@@ -132,7 +132,7 @@ export default class SwitchableRenderer extends BaseRenderer {
                     this._fetchAssetCollection(choice.choice_representation.asset_collections.icon.default_id)
                         .then((icon) => {
                             if (icon.assets.image_src) {
-                                return this._fetchMedia(icon.assets.image_src);
+                                return this._fetchMedia(icon.assets.image_src, { includeCredentials: true });
                             }
                             return Promise.resolve();
                         })
@@ -175,7 +175,7 @@ export default class SwitchableRenderer extends BaseRenderer {
                         this._fetchAssetCollection(choice.choice_representation.asset_collections.icon.default_id)
                             .then((icon) => {
                                 if (icon.assets.image_src) {
-                                    this._fetchMedia(icon.assets.image_src)
+                                    this._fetchMedia(icon.assets.image_src, { includeCredentials: true })
                                         .then(setRepresentationControl)
                                         .catch((err) => { logger.error(err, 'Notfound'); });
                                 }

--- a/src/renderers/ThreeJsImageRenderer.js
+++ b/src/renderers/ThreeJsImageRenderer.js
@@ -118,7 +118,7 @@ export default class ThreeJsImageRenderer extends BaseTimedIntervalRenderer {
             const fg = await this._fetchAssetCollection(this._representation.asset_collections.foreground_id);
             if (fg.assets.image_src) {
                 try {
-                    const mediaUrl = await this._fetchMedia(fg.assets.image_src);
+                    const mediaUrl = await this._fetchMedia(fg.assets.image_src, { includeCredentials: true });
                     this._imageMesh = ThreeJSDriver.loadImage(mediaUrl)
                 } catch(err) {
                     throw new Error('Could not resolve media source for 360 image');


### PR DESCRIPTION
# Details
Sends the `includeCredentials` option to the media resolver so we can use from within SMP plugin

https://github.com/bbc/rd-ux-media-resolver/blob/c959a5246034cd9acde56df75eebce229003b75c/src/ipStudio.js#L18

# Ticket / issue URL
Ticket / issue URL: 

# PR Checks
(tick as appropriate) 

- [ ] PR is linked to ticket / issue
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [x] PR has the package.json version bumped 
