### PR TITLE
fix: uses auth conditionally in SMP

### DIFF
--- a/src/behaviours/TextOverlayBehaviourHelper.js
+++ b/src/behaviours/TextOverlayBehaviourHelper.js
@@ -43,7 +43,8 @@ export const renderTextOverlay = (behaviour, target, callback, controller) => {
             const contentEl = document.createElement('div');
             contentEl.innerHTML = newText.trim();
             const scripts = contentEl.getElementsByTagName('script');
-            scripts.forEach(s => {
+            const scriptEls = Array.from(scripts);
+            scriptEls.forEach(s => {
                 logger.warn(`removing script element from text overlay behaviour ${behaviour.id}`);
                 s.remove();
             });

--- a/src/playoutEngines/SMPPlayoutEngine.js
+++ b/src/playoutEngines/SMPPlayoutEngine.js
@@ -225,7 +225,8 @@ class SMPPlayoutEngine extends BasePlayoutEngine {
             }
         }
 
-        playlist.options.useCredentials = ["MPD", "InitializationSegment", "MediaSegment", "Player"];
+        const isPid = /^[a-z0-9]{8}$/.test(url);
+        playlist.options.useCredentials = isPid ? false : ["MPD", "InitializationSegment", "MediaSegment", "Player"];
 
         logger.info(`SMP-SP readyPlaylist: ${rendererId}`)
         this._smpPlayerInterface.readyPlaylist(playlist)


### PR DESCRIPTION
# Details
Published subtitles cannot be fetched with `useCredentials` set.  Therefore only set this if media is not a PID.

Also fixes error where wrongly trying to use `forEach` to iterate over HTMLCollection (when stripping `<script>`s from text overlays

# Ticket / issue URL
Ticket / issue URL: 

# PR Checks
(tick as appropriate) 

- [ ] PR is linked to ticket / issue
- [ ] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [ ] PR has the package.json version bumped 
