### PR TITLE
fix: inspects subtitles file contents to determine format

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/storyplayer",
-  "version": "1.1.24",
+  "version": "1.1.25",
   "description": "StoryPlayer - reference player for BBC Research & Development's object-based media schema (https://www.npmjs.com/package/@bbc/object-based-media-schema)",
   "main": "dist/storyplayer.js",
   "keywords": [

--- a/src/playoutEngines/SMPPlayoutEngine.js
+++ b/src/playoutEngines/SMPPlayoutEngine.js
@@ -144,7 +144,7 @@ class SMPPlayoutEngine extends BasePlayoutEngine {
         if (!startNow) this.pause()
     }
 
-    queuePlayout(rendererId: string, mediaObj: Object) {
+    async queuePlayout(rendererId: string, mediaObj: Object) {
         if(mediaObj.type === MEDIA_TYPES.BACKGROUND_A) {
             // Handle with Secondary Playout
             this._secondaryPlayoutEngine.queuePlayout(rendererId, mediaObj)
@@ -169,12 +169,14 @@ class SMPPlayoutEngine extends BasePlayoutEngine {
         let playlistItem = {}
         // Check if we have subtitles and that they are EBU-TT-D and not WebVTT
         if(
-            "subs_url" in this._media[rendererId].media &&
-            this._media[rendererId].media.subs_url.substr(-4) === ".xml"
-        ) {
-
-            playlistItem.captionsUrl = this._media[rendererId].media.subs_url;
+            "subs_url" in this._media[rendererId].media
+        ) { 
+            const subsAreEbuttFormat = await fetch(this._media[rendererId].media.subs_url)
+                .then(res => res.text())
+                .then(text => text.includes('xmlns="http://www.w3.org/ns/ttml"')); // is this too much?  too little?
+            if (subsAreEbuttFormat) playlistItem.captionsUrl = this._media[rendererId].media.subs_url;
         }
+
         let kind = "programme"
         if(mediaObj.type === MEDIA_TYPES.FOREGROUND_A) {
             kind = "audio"

--- a/src/renderers/BaseTimedMediaRenderer.js
+++ b/src/renderers/BaseTimedMediaRenderer.js
@@ -213,7 +213,7 @@ export default class BaseTimedMediaRenderer extends BaseRenderer {
                     logger.warn('trying to populate video element that has been destroyed');
                 } else {
                     mediaObj.url = mediaUrl
-                    this._playoutEngine.queuePlayout(this._rendererId, mediaObj);
+                    await this._playoutEngine.queuePlayout(this._rendererId, mediaObj);
                 }
             } else {
                 throw new Error('No av source for video');


### PR DESCRIPTION
# Details
Fixes the problem that EBU-TT subtitles are not playable before publishing.

The problem was that upload-ingest and the media resolver return a filename that doesn't have a `.xml` extension; which was used to distinguish VTT subs (suitable only for our player) and EBU-TT-D (required for SMP playout).  This fix takes the clumsy approach of fetching the file and inspecting the content.

Note that when media is published, this `captionsUrl` is not respected; the subs need publishing through galileo too.

# Ticket / issue URL
Ticket / issue URL: https://jira.dev.bbc.co.uk/browse/PRODTOOLS-3528

# PR Checks
(tick as appropriate) 

- [x] PR is linked to ticket / issue
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [x] PR has the package.json version bumped 
