### PR TITLE
fix: tweaks renderer start to stop fade glitches

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/storyplayer",
-  "version": "1.1.26",
+  "version": "1.1.27",
   "description": "StoryPlayer - reference player for BBC Research & Development's object-based media schema (https://www.npmjs.com/package/@bbc/object-based-media-schema)",
   "main": "dist/storyplayer.js",
   "keywords": [

--- a/src/renderers/BaseRenderer.js
+++ b/src/renderers/BaseRenderer.js
@@ -358,13 +358,16 @@ export default class BaseRenderer extends EventEmitter {
     start() {
         this._setPhase(RENDERER_PHASES.MAIN);
         this._player.exitStartBehaviourPhase();
+        this._clearBehaviourElements();
+        
+        this._runDuringBehaviours(); // queue up all during events
+        this._serviceTimedEvents(); // run any that should start at 0
+
         clearInterval(this._timedEventsInterval);
         this._timedEventsInterval = setInterval(this._serviceTimedEvents, TIMER_INTERVAL);
         this.emit(RendererEvents.STARTED);
-        this._clearBehaviourElements();
         this._player.connectScrubBar(this);
         this._player.on(PlayerEvents.PLAY_PAUSE_BUTTON_CLICKED, this._handlePlayPauseButtonClicked);
-        this._runDuringBehaviours();
         this._player.hideSeekButtons();
     }
 
@@ -755,7 +758,7 @@ export default class BaseRenderer extends EventEmitter {
     }
 
     _runDuringBehaviours() {
-        // run during behaviours
+        // run during behaviours (add them to the queue to be run at appropriate time)
         if (this._representation.behaviours && this._representation.behaviours.during) {
             const duringBehaviours = this._representation.behaviours.during;
             duringBehaviours.forEach((behaviour) => {

--- a/src/renderers/ImageRenderer.js
+++ b/src/renderers/ImageRenderer.js
@@ -19,8 +19,6 @@ export default class ImageRenderer extends BaseTimedIntervalRenderer {
 
     _enableScrubBar: Function;
 
-    _visible: boolean;
-
     _duration: number;
 
     constructor(
@@ -61,7 +59,6 @@ export default class ImageRenderer extends BaseTimedIntervalRenderer {
 
         const duration = this.getDuration();
         this._playoutEngine.startNonAVPlayout(this._rendererId, duration)
-        this._visible = true;
         this._setVisibility(true);
         return true;
     }
@@ -100,15 +97,7 @@ export default class ImageRenderer extends BaseTimedIntervalRenderer {
         if (!needToEnd) return false;
         this._playoutEngine.stopNonAVPlayout(this._rendererId)
 
-        this._visible = false;
-        // Hack to make image transitions smooth (preventing showing of black background with
-        // loading wheel). For some reason the DOM transition on images is slow, not sure why this
-        // is only the case for images and not video but this fixes it.
-        setTimeout(() => {
-            if (!this._visible) {
-                this._setVisibility(false);
-            }
-        }, 100);
+        this._setVisibility(false);
         return true;
     }
 


### PR DESCRIPTION
# Details
Fade in/out on image elements can show glitches - the image can flash up before fade-in starts or after fade-out finishes.  This tweaks the timing of calls in `start()` to fix these.

# Ticket / issue URL
Ticket / issue URL: 

# PR Checks
(tick as appropriate) 

- [x] PR is linked to ticket / issue
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [x] PR has the package.json version bumped 
