### PR TITLE
feat: uses new flag to pause variables panels

### DIFF
--- a/src/behaviours/VariablePanelHelper.js
+++ b/src/behaviours/VariablePanelHelper.js
@@ -342,6 +342,10 @@ export const buildPanel = (
     player.setNextAvailable(false);
     renderer.inVariablePanel = true; // eslint-disable-line no-param-reassign
 
+    // does behaviour definition want us to pause?
+    const pauseWhileShowing = (behaviour.pause_content !== undefined) ? behaviour.pause_content : true;
+    if (pauseWhileShowing) renderer.pause();
+
     const {
         overlayImageElement,
         carouselDiv,
@@ -413,6 +417,7 @@ export const buildPanel = (
                     setTimeout(() => {
                         player.enableControls();
                         player.setNextAvailable(true);
+                        if (pauseWhileShowing) renderer.play();
                         return callback();
                     }, 700);
                     return false;

--- a/src/renderers/BaseTimedMediaRenderer.js
+++ b/src/renderers/BaseTimedMediaRenderer.js
@@ -152,8 +152,9 @@ export default class BaseTimedMediaRenderer extends BaseRenderer {
         }
 
         if (
-            (!isLooping && isEnded) ||
-            (isLooping && this._accumulatedMediaTime >= duration)
+            ((!isLooping && isEnded) ||
+            (isLooping && this._accumulatedMediaTime >= duration)) &&
+            !this.inVariablePanel // wait until variable panel completed
         ) {
             // Some players fallback to first frame--force showing ending frame.
             this._playoutEngine.setCurrentTime(this._rendererId, duration-0.1);

--- a/src/renderers/ImageRenderer.js
+++ b/src/renderers/ImageRenderer.js
@@ -86,9 +86,19 @@ export default class ImageRenderer extends BaseTimedIntervalRenderer {
                 () => {
                     // eslint-disable-next-line max-len
                     logger.info(`Image representation ${this._representation.id} completed time`);
-                    this.complete();
+                    this._testIfInVarPanel();
                 },
             );
+        }
+    }
+
+    // tests if we're in a variable panel, and waits until we've finished before moving on
+    _testIfInVarPanel() {
+        if (!this.inVariablePanel) {
+            this.complete();
+        }
+        else {
+            setTimeout(() => this._testIfInVarPanel(), 100);
         }
     }
 


### PR DESCRIPTION
# Details
Allows variables panels to be used as `during` behaviours and for content to pause while they show.  This will allow us to remove `started` behaviours.
 
Schema change: https://github.com/bbc/object-based-media-schema/pull/13, but this will work with current schema, defaulting to pausing content under the panel.

# Ticket / issue URL
Ticket / issue URL: 

# PR Checks
(tick as appropriate) 

- [x] PR is linked to ticket / issue
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [ ] PR has the package.json version bumped 
