### PR TITLE
fix: does not set attribute if icon undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/storyplayer",
-  "version": "1.1.32",
+  "version": "1.1.33",
   "description": "StoryPlayer - reference player for BBC Research & Development's object-based media schema (https://www.npmjs.com/package/@bbc/object-based-media-schema)",
   "main": "dist/storyplayer.js",
   "keywords": [

--- a/src/renderers/BaseRenderer.js
+++ b/src/renderers/BaseRenderer.js
@@ -937,13 +937,13 @@ export default class BaseRenderer extends EventEmitter {
                         this._linkBehaviour.forceChoice = false;
                         callback();
                     }
-                // }).catch((err) => {
-                //     logger.error(err, 'could not get assets for rendering link icons');
-                //     callback();
+                }).catch((err) => {
+                    logger.error(err, 'could not get assets for rendering link icons');
+                    callback();
                 });
-        // }).catch((err) => {
-        //     logger.error(err, 'Could not get next steps for rendering links');
-        //     callback();
+        }).catch((err) => {
+            logger.error(err, 'Could not get next steps for rendering links');
+            callback();
         });
     }
 

--- a/src/renderers/BaseRenderer.js
+++ b/src/renderers/BaseRenderer.js
@@ -937,13 +937,13 @@ export default class BaseRenderer extends EventEmitter {
                         this._linkBehaviour.forceChoice = false;
                         callback();
                     }
-                }).catch((err) => {
-                    logger.error(err, 'could not get assets for rendering link icons');
-                    callback();
+                // }).catch((err) => {
+                //     logger.error(err, 'could not get assets for rendering link icons');
+                //     callback();
                 });
-        }).catch((err) => {
-            logger.error(err, 'Could not get next steps for rendering links');
-            callback();
+        // }).catch((err) => {
+        //     logger.error(err, 'Could not get next steps for rendering links');
+        //     callback();
         });
     }
 
@@ -1113,7 +1113,7 @@ export default class BaseRenderer extends EventEmitter {
         } else {
             logger.warn(`No icon specified for link to ${targetId} - not rendering`);
         }
-        icon.setAttribute('spatial-navigation-object', 'content');
+        if (icon) icon.setAttribute('spatial-navigation-object', 'content');
         if (icon && iconObject.position && iconObject.position.two_d) {
             const {
                 left,


### PR DESCRIPTION
# Details
If a link isn't rendered, the base renderer was still trying to add the spatial navigation attribute, but to an undefined object.  Fixed 

# Ticket / issue URL
Ticket / issue URL: 

# PR Checks
(tick as appropriate) 

- [ ] PR is linked to ticket / issue
- [ ] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [ ] PR has the package.json version bumped 
