### PR TITLE
fix: replaces window.top with parent, bumps to 1.1.35

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/storyplayer",
-  "version": "1.1.34",
+  "version": "1.1.35",
   "description": "StoryPlayer - reference player for BBC Research & Development's object-based media schema (https://www.npmjs.com/package/@bbc/object-based-media-schema)",
   "main": "dist/storyplayer.js",
   "keywords": [

--- a/src/gui/Player.js
+++ b/src/gui/Player.js
@@ -216,7 +216,8 @@ class Player extends EventEmitter {
         this._isPausedForBehaviours = false;
 
         this.useExternalTransport = 
-            new URLSearchParams(window.top.location.search).getAll('noUi').length > 0 
+            // eslint-disable-next-line no-restricted-globals
+            new URLSearchParams(parent.location.search).getAll('noUi').length > 0 
             || this._controller.options?.noUi;
 
         // initiate spatial navigation


### PR DESCRIPTION
# Details
Uses parent in place of window.top so that PX doesn't have CORS issues when running inside nested iFrames

# Ticket / issue URL
Ticket / issue URL: 

# PR Checks
(tick as appropriate) 

- [ ] PR is linked to ticket / issue
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [x] PR has the package.json version bumped 
