### PR TITLE
feat: styles link choices to support PX work

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/storyplayer",
-  "version": "1.1.36",
+  "version": "1.1.37",
   "description": "StoryPlayer - reference player for BBC Research & Development's object-based media schema (https://www.npmjs.com/package/@bbc/object-based-media-schema)",
   "main": "dist/storyplayer.js",
   "keywords": [

--- a/src/assets/styles/colours.scss
+++ b/src/assets/styles/colours.scss
@@ -23,3 +23,6 @@ $var-panel-border: rgba(255, 255, 255, 0.2);
 $half-white: rgba(255, 255, 255, 0.5);
 
 $smp-text-white: #d8d8d8;
+
+$px-border: #6d51d2;
+$px-highlight: #24c4f7;

--- a/src/assets/styles/player.scss
+++ b/src/assets/styles/player.scss
@@ -1,6 +1,7 @@
 @import './colours';
 @import './social';
 @import './functions';
+@import './px';
 
 $romper-button-height: 25px;
 $romper-button-width: 25px;
@@ -804,10 +805,6 @@ $start-button-size: 15vw;
         }
       }
     }
-  }
-
-  .romper-link-choice-grid-cell {
-    opacity: 1;
   }
 }
 

--- a/src/assets/styles/player.scss
+++ b/src/assets/styles/player.scss
@@ -806,6 +806,10 @@ $start-button-size: 15vw;
       }
     }
   }
+
+  .romper-link-choice-grid-cell {
+    opacity: 1;
+  }
 }
 
 .romper-link-icon-container {

--- a/src/assets/styles/px.scss
+++ b/src/assets/styles/px.scss
@@ -94,8 +94,8 @@ $px-border-width: 50px;
       }
     }
 
-    .romper-control-unselected {
-
+    .romper-control-unselected,
+    .romper-control-selected {
       &.default {
         &.text {
           border: 5px solid $px-highlight;
@@ -108,11 +108,13 @@ $px-border-width: 50px;
     }
   }
 
-  .romper-player > .romper-gui > .romper-overlays {
-    &.keyboard-active {
-      .romper-link-control {
-        &:focus {
-          border: 5px solid $px-border;
+  .romper-gui > .romper-overlays.keyboard-active { // sass-lint:disable-line force-element-nesting
+    .romper-link-control {
+      &:focus {
+        border: 5px solid $px-border;
+
+        &.default {
+          border: 5px solid $px-highlight;
         }
       }
     }

--- a/src/assets/styles/px.scss
+++ b/src/assets/styles/px.scss
@@ -1,0 +1,126 @@
+$px-button-width: 470px;
+$px-screen-width: 1920px;
+$px-border-width: 50px;
+
+// skin to style choices as a carousel for PX
+.px .romper-player { // sass-lint:disable-line force-element-nesting
+  .romper-link-choice-overlay {
+    display: inline-flex;
+    padding: 85px (2 * $px-border-width) $px-border-width;
+    width: $px-screen-width - (4 * $px-border-width);
+
+    &.focused-3 {
+      .romper-link-control {
+        transform: translate(-$px-button-width, 0);
+      }
+    }
+
+    &.focused-4 {
+      .romper-link-control {
+        transform: translate(-2 * $px-button-width, 0);
+      }
+    }
+
+    &.focused-5 {
+      .romper-link-control {
+        transform: translate(-3 * $px-button-width, 0);
+      }
+    }
+
+    &.focused-6 {
+      .romper-link-control {
+        transform: translate(-4 * $px-button-width, 0);
+      }
+    }
+
+    &.focused-7 {
+      .romper-link-control {
+        transform: translate(-5 * $px-button-width, 0);
+      }
+    }
+
+    &.focused-8 {
+      .romper-link-control {
+        transform: translate(-6 * $px-button-width, 0);
+      }
+    }
+
+    &.focused-9 {
+      .romper-link-control {
+        transform: translate(-7 * $px-button-width, 0);
+      }
+    }
+
+    &.focused-10 {
+      .romper-link-control {
+        transform: translate(-8 * $px-button-width, 0);
+      }
+    }
+
+    .romper-link-control {
+      border: 5px solid $px-border;
+      margin: 0 $px-border-width;
+      max-width: $px-button-width;
+      min-width: $px-button-width;
+
+      &:nth-child(2) {
+        margin-left: auto;
+      }
+
+      &:last-child {
+        margin-right: auto;
+      }
+
+      &:focus {
+        background: $px-border;
+        border: 5px solid $px-border;
+      }
+    }
+
+    .romper-ux-divider {
+      border-bottom: 2px solid $white;
+      left: 0;
+      width: $px-screen-width;
+    }
+
+    .romper-control-selected {
+
+      &.text {
+        border: 5px solid $px-highlight;
+      }
+
+      .romper-link-icon-container {
+        border: 5px solid $px-highlight;
+      }
+    }
+
+    .romper-control-unselected {
+
+      &.default {
+        &.text {
+          border: 5px solid $px-highlight;
+        }
+
+        .romper-link-icon-container {
+          border: 5px solid $px-highlight;
+        }
+      }
+    }
+  }
+
+  .romper-player > .romper-gui > .romper-overlays {
+    &.keyboard-active {
+      .romper-link-control {
+        &:focus {
+          border: 5px solid $px-border;
+        }
+      }
+    }
+  }
+
+  .romper-ux-countdown {
+    background: $px-highlight;
+    height: 6px;
+    transform: translate(0 -3px);
+  }
+}

--- a/src/gui/Player.js
+++ b/src/gui/Player.js
@@ -1278,7 +1278,15 @@ class Player extends EventEmitter {
             behaviourElement.classList.remove('threerow');
         }
 
+        const linkIndex = this._numChoices;
         const linkChoiceControl = document.createElement('button');
+        linkChoiceControl.onfocus = () => { 
+            const linkChoices = this.getLinkChoiceElement()[0];
+            for (let i = 0; i < 10; i += 1) {
+                linkChoices.classList.remove(`focused-${i}`);
+            }
+            linkChoices.classList.add(`focused-${linkIndex}`);
+        }
         linkChoiceControl.id = `romper-link-choice-${id}`;
         linkChoiceControl.tabIndex = 2;
         const containerPromise = new Promise((resolve) => {


### PR DESCRIPTION
# Details
Adds some styling to allow link choices to be styled in the way the PX/UX team have designed [see Figma](https://www.figma.com/file/EMgGNvuIqIbYBjcGKiHxw1/PX_UI?node-id=2657%3A3398).

Mostly CSS, but adds a little code to set classes as choices are focused.

To actually apply, will need SPH to take a parameter from the plugin config and set a class on the `playerInteface.container`.

Testing: [here's a story](https://storyplayer-test.pilots.bbcconnectedstudio.co.uk/private/deed259a-811a-435f-a672-bae84ff42aa1) you can use (but might be good to test with more links, and with SMP player).  Code will only work with up to 10 links.  You will also need to manually add the `px` class to one of the higher level elements (e.g., the `div` that has the `romper-target` class).

Note that PX screen is fixed at 1920x1080 (you can force this for testing by editing [this function in SPH](https://github.com/bbc/rd-ux-storyplayer-harness/blob/8640e4ed865089f82a0344015c94d5af327d3fe4/client/helpers/utils.js#L91) to always set size to these values).

# Ticket / issue URL
Ticket / issue URL: https://jira.dev.bbc.co.uk/browse/PRODTOOLS-3660

# PR Checks
(tick as appropriate) 

- [x] PR is linked to ticket / issue
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [ ] PR has the package.json version bumped 
