### PR TITLE
feat: allows an options setting to be passed in

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/storyplayer",
-  "version": "1.1.37",
+  "version": "1.1.38",
   "description": "StoryPlayer - reference player for BBC Research & Development's object-based media schema (https://www.npmjs.com/package/@bbc/object-based-media-schema)",
   "main": "dist/storyplayer.js",
   "keywords": [

--- a/src/Controller.js
+++ b/src/Controller.js
@@ -41,6 +41,7 @@ export default class Controller extends EventEmitter {
         privacyNotice: ?string,
         saveSession: ?boolean,
         handleKeys: ?boolean,
+        options: ?Object,
     ) {
         super();
         this._storyId = null;
@@ -63,6 +64,8 @@ export default class Controller extends EventEmitter {
 
         this._analyticsHandler = new AnalyticsHandler(analytics, this);
         this._handleAnalytics = this._handleAnalytics.bind(this);
+
+        this.options = options;
 
         this._assetUrls = assetUrls;
         this._privacyNotice = privacyNotice;
@@ -102,6 +105,10 @@ export default class Controller extends EventEmitter {
         } else {
             this.start(restartStoryId, initialState);
         }
+    }
+
+    updateOptions(newOptions: Object) {
+        this.options = newOptions;
     }
 
     /**

--- a/src/gui/Player.js
+++ b/src/gui/Player.js
@@ -215,10 +215,13 @@ class Player extends EventEmitter {
         logger.debug("Playout debugging: ON");
         this._isPausedForBehaviours = false;
 
-        this.useExternalTransport = 
+        this.useExternalTransport = () => {
             // eslint-disable-next-line no-restricted-globals
-            new URLSearchParams(parent.location.search).getAll('noUi').length > 0 
-            || this._controller.options?.noUi;
+            const useExternal = new URLSearchParams(parent.location.search).getAll('noUi').length > 0 
+                || this._controller.options?.noUi;
+            if (useExternal === undefined) return false;
+            return useExternal;
+        }
 
         // initiate spatial navigation
         // do we want to include UI?

--- a/src/gui/SMPControls.js
+++ b/src/gui/SMPControls.js
@@ -54,7 +54,7 @@ class SMPControls extends BaseControls {
         chapterOverlay: Overlay,
         switchableOverlay: Overlay,
         playoutEngine: BasePlayoutEngine,
-        useExternalTransport: boolean,
+        useExternalTransport: function,
     ) {
         super(logUserInteraction, volumeOverlay, chapterOverlay, switchableOverlay);
 
@@ -77,7 +77,7 @@ class SMPControls extends BaseControls {
         this._setupAnalytics();
 
         // Controls enabled by default
-        this._controlsEnabled = (true && !this._useExternalTransport)
+        this._controlsEnabled = (true && !this._useExternalTransport())
 
         this._containerDiv = createElementWithClass(
             'div',
@@ -245,7 +245,7 @@ class SMPControls extends BaseControls {
             chromecast: { enabled: false },
             controls: {
                 volumeDismissTime: 5000,
-                enabled: true,
+                enabled: !this._useExternalTransport(),
                 spaceControlsPlayback: true,
                 availableOnMediaEnded: true,
                 includeNextButton: true,
@@ -452,7 +452,7 @@ class SMPControls extends BaseControls {
 
     enableControls() {
         this._smpPlayerInterface.dispatchEvent({ type: 'PLUGIN_UI', myData: "ENABLE_CONTROLS"});
-        if(this._controlsEnabled !== true && !this._useExternalTransport) {
+        if(this._controlsEnabled !== true && !this._useExternalTransport()) {
             this._uiUpdate({
                 enabled: true,
             })
@@ -504,6 +504,10 @@ class SMPControls extends BaseControls {
 
     showScrubBar() {
         // Called from showSeekButtons in player
+    }
+
+    focusScrubBar() {
+        // can't do this
     }
 
     enableScrubBar() {

--- a/src/storyplayer.js
+++ b/src/storyplayer.js
@@ -50,6 +50,7 @@ const DEFAULT_SETTINGS = {
     privacyNotice: null,
     saveSession: false,
     handleKeys: true,
+    noUi: false,
 };
 
 // Limited Debugging for iOS webviews
@@ -163,6 +164,7 @@ module.exports = {
             mergedSettings.privacyNotice,
             mergedSettings.saveSession,
             mergedSettings.handleKeys,
+            mergedSettings.options,
         );
     },
 };


### PR DESCRIPTION
# Details
storyplayer.js can be passed an `options` object, and have it updated at any time.  This is currently only used to turn the UI off, so that PX can use an external interface

# Ticket / issue URL
Ticket / issue URL:  https://jira.dev.bbc.co.uk/browse/PRODTOOLS-3658

# PR Checks
(tick as appropriate) 

- [x] PR is linked to ticket / issue
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [x] PR has the package.json version bumped 
