### PR TITLE
fix: focuses resume button and enables keyboard selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/storyplayer",
-  "version": "1.1.38",
+  "version": "1.1.39",
   "description": "StoryPlayer - reference player for BBC Research & Development's object-based media schema (https://www.npmjs.com/package/@bbc/object-based-media-schema)",
   "main": "dist/storyplayer.js",
   "keywords": [

--- a/src/gui/Player.js
+++ b/src/gui/Player.js
@@ -433,6 +433,14 @@ class Player extends EventEmitter {
             this._toggleFullScreen();
             event.preventDefault();
         }
+
+        // PX will emit standard html key events
+        // need these here to allow PX users to choose restart/resume
+        if (event.code === 'ArrowUp') this._spatialNavigationHandler.goUp();
+        if (event.code === 'ArrowRight') this._spatialNavigationHandler.goRight();
+        if (event.code === 'ArrowLeft') this._spatialNavigationHandler.goLeft();
+        if (event.code === 'ArrowDown' ) this._spatialNavigationHandler.goDown();
+
         if (!this._userInteractionStarted) return true;
         // numbers activate link choices
         const keyNumber = parseInt(event.key, 10);
@@ -445,12 +453,6 @@ class Player extends EventEmitter {
                 this._visibleChoices[keyNumber].dispatchEvent(newMouseEvent, true);
             }
         }
-
-        // PX will emit standard html key events
-        if (event.code === 'ArrowUp') this._spatialNavigationHandler.goUp();
-        if (event.code === 'ArrowRight') this._spatialNavigationHandler.goRight();
-        if (event.code === 'ArrowLeft') this._spatialNavigationHandler.goLeft();
-        if (event.code === 'ArrowDown' ) this._spatialNavigationHandler.goDown();
 
         if(!this._keyboardActiveTimeout) {
             this._overlaysElement.classList.add('keyboard-active');
@@ -664,6 +666,7 @@ class Player extends EventEmitter {
             this._continueModalLayer.classList.add('show');
             this._continueModalContent.classList.add('show');
         }
+        resumeButton.focus();
     }
 
     // TODO: this needs proper testing!


### PR DESCRIPTION
# Details
PX users see the restart/resume screen with neither button focused and cannot do anything.  This fixes to focus the resume button and allow spatial nav to switch between buttons

bumps version to 1.1.39

# Ticket / issue URL
Ticket / issue URL: 

# PR Checks
(tick as appropriate) 

- [ ] PR is linked to ticket / issue
- [ ] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [ ] PR has the package.json version bumped 
