### PR TITLE
fix: fixes bug where controls not shown on element after choice

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/storyplayer",
-  "version": "1.1.44",
+  "version": "1.1.45",
   "description": "StoryPlayer - reference player for BBC Research & Development's object-based media schema (https://www.npmjs.com/package/@bbc/object-based-media-schema)",
   "main": "dist/storyplayer.js",
   "keywords": [

--- a/src/gui/Player.js
+++ b/src/gui/Player.js
@@ -163,8 +163,6 @@ class Player extends EventEmitter {
 
     _addCountdownToElement: Function;
 
-    _isPausedForBehaviours: boolean;
-
     _controller: Controller;
 
     userSetForegroundVolume: Number;
@@ -210,7 +208,6 @@ class Player extends EventEmitter {
         this._handleFullScreenEvent = this._handleFullScreenEvent.bind(this);
 
         logger.debug("Playout debugging: ON");
-        this._isPausedForBehaviours = false;
 
         this.useExternalTransport = () => {
             // eslint-disable-next-line no-restricted-globals
@@ -921,8 +918,8 @@ class Player extends EventEmitter {
         this._userInteractionStarted = true;
         this._overlaysElement.classList.remove('romper-inactive');
 
-        // can start now if we're not waiting in START behaviours
-        // that means in MAIN, or (for untimed representations) in MEDIA_FINISHED
+        // can start now if we're
+        // in MAIN, or (for untimed representations) in MEDIA_FINISHED
         const startNow = (this._currentRenderer
             && (this._currentRenderer.phase === RENDERER_PHASES.MAIN
             || this._currentRenderer.phase === RENDERER_PHASES.MEDIA_FINISHED));
@@ -938,10 +935,6 @@ class Player extends EventEmitter {
         if (startNow && this.playoutEngine.isPlayingNonAV()) {
             // Kick off non-AV that doesn't use a playout engine.
             this._currentRenderer.play();
-        }
-
-        if (this._currentRenderer && this._currentRenderer.phase === RENDERER_PHASES.START) {
-            this._isPausedForBehaviours = true;
         }
 
         this._logUserInteraction(AnalyticEvents.names.START_BUTTON_CLICKED);
@@ -1495,22 +1488,6 @@ class Player extends EventEmitter {
         this._controls.disableSeekBack();
         this.disablePlayButton();
         this._disableRepresentationControl();
-    }
-
-    _pauseForBehaviours() {
-        if (this.playoutEngine.isPlaying()) {
-            this._isPausedForBehaviours = true;
-            this.playoutEngine.pause();
-        }
-        this._controls.disablePlayButton();
-    }
-
-    _unpauseAfterBehaviours() {
-        if (this._isPausedForBehaviours) {
-            this._isPausedForBehaviours = false;
-            this.playoutEngine.play();
-        }
-        this._controls.enablePlayButton();
     }
 
     exitCompleteBehaviourPhase() {

--- a/src/playoutEngines/DOMSwitchPlayoutEngine.js
+++ b/src/playoutEngines/DOMSwitchPlayoutEngine.js
@@ -435,7 +435,7 @@ export default class DOMSwitchPlayoutEngine extends BasePlayoutEngine {
 
     setPlayoutActive(rendererId: string) {
         const rendererPlayoutObj = this._media[rendererId];
-        if (this._media[rendererId].error === true) {
+        if (this._media[rendererId] && this._media[rendererId].error === true) {
             this._player._showErrorLayer()
         }
         if (!rendererPlayoutObj) {


### PR DESCRIPTION
# Details
Fixes a bug introduced when started behaviours were removed: the controls hidden during a choice, but not made available again on the next element.

Also removes some more started behaviour code that is no longer needed and clears a console error that arose from the playout engine when starting up the experience

# Ticket / issue URL
Ticket / issue URL:  https://jira.dev.bbc.co.uk/browse/PRODTOOLS-3645

# PR Checks
(tick as appropriate) 

- [x] PR is linked to ticket / issue
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [ ] PR has the package.json version bumped 
