### PR TITLE
fix: corrects test for subtitle availability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/storyplayer",
-  "version": "1.1.45",
+  "version": "1.1.46",
   "description": "StoryPlayer - reference player for BBC Research & Development's object-based media schema (https://www.npmjs.com/package/@bbc/object-based-media-schema)",
   "main": "dist/storyplayer.js",
   "keywords": [

--- a/src/playoutEngines/DOMSwitchPlayoutEngine.js
+++ b/src/playoutEngines/DOMSwitchPlayoutEngine.js
@@ -552,7 +552,7 @@ export default class DOMSwitchPlayoutEngine extends BasePlayoutEngine {
             if (this._playing && rendererPlayoutObj.media && rendererPlayoutObj.media.url) {
                 this.play();
             }
-            if (rendererPlayoutObj.media && rendererPlayoutObj.media.subs_src) {
+            if (rendererPlayoutObj.media && rendererPlayoutObj.media.subs_url) {
                 this._showHideSubtitles(rendererId);
                 this._player.enableSubtitlesControl();
             }


### PR DESCRIPTION
# Details
Subtitles button wasn't showing at the right times.  Fixes.  [Test story](https://storyplayer-test.pilots.bbcconnectedstudio.co.uk/private/fb67d05d-9372-4e85-a37e-3ef501ff4031) has WebVTT subs on second element (note that the player does not distinguish what type of subs are available, so it sees that there are some in Element 1, but can't render them).

# Ticket / issue URL
Ticket / issue URL: https://jira.dev.bbc.co.uk/browse/PRODTOOLS-3766

# PR Checks
(tick as appropriate) 

- [x] PR is linked to ticket / issue
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [x] PR has the package.json version bumped 
