### PR TITLE
fix: corrects renderer start process

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/storyplayer",
-  "version": "1.1.45",
+  "version": "1.1.46",
   "description": "StoryPlayer - reference player for BBC Research & Development's object-based media schema (https://www.npmjs.com/package/@bbc/object-based-media-schema)",
   "main": "dist/storyplayer.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/storyplayer",
-  "version": "1.1.46",
+  "version": "1.1.47",
   "description": "StoryPlayer - reference player for BBC Research & Development's object-based media schema (https://www.npmjs.com/package/@bbc/object-based-media-schema)",
   "main": "dist/storyplayer.js",
   "keywords": [

--- a/src/RenderManager.js
+++ b/src/RenderManager.js
@@ -119,11 +119,7 @@ export default class RenderManager extends EventEmitter {
                 const rend = this._currentRenderer;
                 const choiceTime = rend.getChoiceTime();
                 const { duration, currentTime } = rend.getCurrentTime();
-                if (rend.getInPause() && rend.phase === RENDERER_PHASES.START) {
-                    logger.info('Next button clicked during infinite start pause - starting element'); // eslint-disable-line max-len
-                    rend.exitStartPauseBehaviour();
-                }
-                else if (duration === Infinity){
+                if (duration === Infinity){
                     logger.info('Next button clicked during infinite representation - completing element'); // eslint-disable-line max-len
                     this._currentRenderer.complete();
                 }
@@ -774,10 +770,6 @@ export default class RenderManager extends EventEmitter {
         }
         if (this._currentRenderer) {
             const rend = this._currentRenderer;
-            if (rend.getInPause() && rend.phase === RENDERER_PHASES.START) {
-                this._player.setNextAvailable(!nextForceHide);
-                return Promise.resolve();
-            }
             if (!rend.inVariablePanel) {
                 return this._controller.getValidNextSteps()
                     .then((nextSteps) => {

--- a/src/RenderManager.js
+++ b/src/RenderManager.js
@@ -119,7 +119,11 @@ export default class RenderManager extends EventEmitter {
                 const rend = this._currentRenderer;
                 const choiceTime = rend.getChoiceTime();
                 const { duration, currentTime } = rend.getCurrentTime();
-                if (duration === Infinity){
+                if (rend.getInPause() && rend.phase === RENDERER_PHASES.START) {
+                    logger.info('Next button clicked during infinite start pause - starting element'); // eslint-disable-line max-len
+                    rend.exitStartPauseBehaviour();
+                }
+                else if (duration === Infinity){
                     logger.info('Next button clicked during infinite representation - completing element'); // eslint-disable-line max-len
                     this._currentRenderer.complete();
                 }
@@ -770,6 +774,10 @@ export default class RenderManager extends EventEmitter {
         }
         if (this._currentRenderer) {
             const rend = this._currentRenderer;
+            if (rend.getInPause() && rend.phase === RENDERER_PHASES.START) {
+                this._player.setNextAvailable(!nextForceHide);
+                return Promise.resolve();
+            }
             if (!rend.inVariablePanel) {
                 return this._controller.getValidNextSteps()
                     .then((nextSteps) => {

--- a/src/renderers/BaseRenderer.js
+++ b/src/renderers/BaseRenderer.js
@@ -308,7 +308,7 @@ export default class BaseRenderer extends EventEmitter {
     start() {
         if (this.phase === RENDERER_PHASES.CONSTRUCTING) {
             setTimeout(() => this.start(), 100);
-            return;
+            return false;
         }
 
         this.emit(RendererEvents.CONSTRUCTED);
@@ -328,6 +328,7 @@ export default class BaseRenderer extends EventEmitter {
         this._player.connectScrubBar(this);
         this._player.on(PlayerEvents.PLAY_PAUSE_BUTTON_CLICKED, this._handlePlayPauseButtonClicked);
         this._player.hideSeekButtons();
+        return true;
     }
 
     end(): boolean {
@@ -579,6 +580,7 @@ export default class BaseRenderer extends EventEmitter {
             try {
                 const assetCollection = await this._fetchAssetCollection(behaviour.asset_collection_id);
                 if (assetCollection.assets.image_src) {
+                    // eslint-disable-next-line max-len
                     const imageUrl = await this._fetchMedia(assetCollection.assets.image_src, { includeCredentials: true });
                     if (imageUrl) {
                         const image = new Image();
@@ -1006,6 +1008,7 @@ export default class BaseRenderer extends EventEmitter {
             const fetcherPromises = [];
             iconObjects.forEach((iconObject) => {
                 if (iconObject && iconObject.ac && iconObject.ac.assets.image_src) {
+                    // eslint-disable-next-line max-len
                     fetcherPromises.push(this._fetchMedia(iconObject.ac.assets.image_src, { includeCredentials: true }));
                 } else {
                     fetcherPromises.push(Promise.resolve(''));

--- a/src/renderers/BaseTimedIntervalRenderer.js
+++ b/src/renderers/BaseTimedIntervalRenderer.js
@@ -137,11 +137,13 @@ export default class TimedMediaRenderer extends BaseRenderer {
     }
 
     start() {
-        super.start();
+        const ready = super.start();
+        if (!ready) return false;
         this._current = 0;
         if (this._playoutEngine.isPlaying()) {
             this.play();
         }
+        return true;
     }
 
     play() {

--- a/src/renderers/BaseTimedMediaRenderer.js
+++ b/src/renderers/BaseTimedMediaRenderer.js
@@ -390,7 +390,8 @@ export default class BaseTimedMediaRenderer extends BaseRenderer {
     }
 
     start() {
-        super.start();
+        const ready = super.start();
+        if (!ready) return false;
         this._playoutEngine.setPlayoutActive(this._rendererId);
 
         clearInterval(this._inspectMediaPlaybackInterval);
@@ -411,6 +412,7 @@ export default class BaseTimedMediaRenderer extends BaseRenderer {
         } else {
             this._player.disableScrubBar();
         }
+        return true;
     }
 
     play() {

--- a/src/renderers/ImageRenderer.js
+++ b/src/renderers/ImageRenderer.js
@@ -54,7 +54,8 @@ export default class ImageRenderer extends BaseTimedIntervalRenderer {
     }
 
     start() {
-        super.start();
+        const ready = super.start();
+        if (!ready) return false;
 
         const duration = this.getDuration();
         this._playoutEngine.startNonAVPlayout(this._rendererId, duration)
@@ -83,6 +84,7 @@ export default class ImageRenderer extends BaseTimedIntervalRenderer {
                 },
             );
         }
+        return true;
     }
 
     // tests if we're in a variable panel, and waits until we've finished before moving on

--- a/src/renderers/SimpleAudioRenderer.js
+++ b/src/renderers/SimpleAudioRenderer.js
@@ -52,8 +52,10 @@ export default class SimpleAudioRenderer extends BaseTimedMediaRenderer {
     }
 
     start() {
-        super.start();
+        const ready = super.start();
+        if (!ready) return false;
         this._setImageVisibility(true);
+        return true;
     }
 
     end() {

--- a/src/renderers/SimpleTextRenderer.js
+++ b/src/renderers/SimpleTextRenderer.js
@@ -96,7 +96,8 @@ export default class SimpleTextRenderer extends BaseTimedIntervalRenderer {
      * @extends BaseRenderer#start()
      */
     start() {
-        super.start();
+        const ready = super.start();
+        if (!ready) return false;
         this._playoutEngine.startNonAVPlayout(this._rendererId, 0)
 
         this._target.appendChild(this._textDiv);
@@ -106,6 +107,7 @@ export default class SimpleTextRenderer extends BaseTimedIntervalRenderer {
         
         // no duration, so ends immediately
         this._setPhase(RENDERER_PHASES.MEDIA_FINISHED);
+        return true;
     }
 
     /**

--- a/src/renderers/SwitchableRenderer.js
+++ b/src/renderers/SwitchableRenderer.js
@@ -288,7 +288,8 @@ export default class SwitchableRenderer extends BaseRenderer {
     }
 
     start() {
-        super.start();
+        const ready = super.start();
+        if (!ready) return false;
         this._setPhase(RENDERER_PHASES.MAIN);
         this._initRemainingRenderers();
         this._previousRendererPlayheadTime = 0;
@@ -300,6 +301,7 @@ export default class SwitchableRenderer extends BaseRenderer {
         if (firstChoice) {
             firstChoice.start();
         }
+        return true;
     }
 
     end() {

--- a/src/renderers/ThreeJsImageRenderer.js
+++ b/src/renderers/ThreeJsImageRenderer.js
@@ -65,7 +65,8 @@ export default class ThreeJsImageRenderer extends BaseTimedIntervalRenderer {
     }
 
     start() {
-        super.start();
+        const ready = super.start();
+        if (!ready) return false;
         const duration = this.getDuration();
         this._playoutEngine.startNonAVPlayout(this._rendererId, duration);
         this._threeJSDriver.init();
@@ -94,6 +95,7 @@ export default class ThreeJsImageRenderer extends BaseTimedIntervalRenderer {
                 },
             );
         }
+        return true;
     }
 
     end() {

--- a/src/renderers/ThreeJsVideoRenderer.js
+++ b/src/renderers/ThreeJsVideoRenderer.js
@@ -52,7 +52,8 @@ export default class ThreeJsVideoRenderer extends BaseTimedMedialRenderer {
     }
 
     start() {
-        super.start();
+        const ready = super.start();
+        if (!ready) return false;
         this._setPhase(RENDERER_PHASES.MAIN);
         this._threeJSDriver.init();
         this._startThreeSixtyVideo();
@@ -60,6 +61,7 @@ export default class ThreeJsVideoRenderer extends BaseTimedMedialRenderer {
         this._player.enablePlayButton();
         this._player.enableScrubBar();
         this._player.showSeekButtons();
+        return true;
     }
 
     _startThreeSixtyVideo() {


### PR DESCRIPTION
# Details
After removing `willStart` with the started behaviours, the full `start()` code of the renderers was being run multiple times while waiting for the `init()` to complete.  This fixes the code so that the main functionality in `start()` is only run once `init()` has completed

# Ticket / issue URL
Ticket / issue URL: https://jira.dev.bbc.co.uk/browse/PRODTOOLS-3767

# PR Checks
(tick as appropriate) 

- [x] PR is linked to ticket / issue
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [x] PR has the package.json version bumped 
