### PR TITLE
fix: sorts out some behaviour problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/storyplayer",
-  "version": "1.1.47",
+  "version": "1.1.48",
   "description": "StoryPlayer - reference player for BBC Research & Development's object-based media schema (https://www.npmjs.com/package/@bbc/object-based-media-schema)",
   "main": "dist/storyplayer.js",
   "keywords": [

--- a/src/RenderManager.js
+++ b/src/RenderManager.js
@@ -119,11 +119,7 @@ export default class RenderManager extends EventEmitter {
                 const rend = this._currentRenderer;
                 const choiceTime = rend.getChoiceTime();
                 const { duration, currentTime } = rend.getCurrentTime();
-                if (rend.getInPause() && rend.phase === RENDERER_PHASES.START) {
-                    logger.info('Next button clicked during infinite start pause - starting element'); // eslint-disable-line max-len
-                    rend.exitStartPauseBehaviour();
-                }
-                else if (duration === Infinity){
+                if (duration === Infinity){
                     logger.info('Next button clicked during infinite representation - completing element'); // eslint-disable-line max-len
                     this._currentRenderer.complete();
                 }
@@ -774,10 +770,6 @@ export default class RenderManager extends EventEmitter {
         }
         if (this._currentRenderer) {
             const rend = this._currentRenderer;
-            if (rend.getInPause() && rend.phase === RENDERER_PHASES.START) {
-                this._player.setNextAvailable(!nextForceHide);
-                return Promise.resolve();
-            }
             if (!rend.inVariablePanel) {
                 return this._controller.getValidNextSteps()
                     .then((nextSteps) => {

--- a/src/behaviours/PauseBehaviour.js
+++ b/src/behaviours/PauseBehaviour.js
@@ -31,6 +31,7 @@ export default class PauseBehaviour extends BaseBehaviour {
 
     handleTimeout() {
         if (!this.isPausing) return;
+        this._renderer.setInPause(false);
         this.isPausing = false;
         this.timerHandle = null;
         this._handleDone();

--- a/src/renderers/BaseRenderer.js
+++ b/src/renderers/BaseRenderer.js
@@ -106,8 +106,6 @@ export default class BaseRenderer extends EventEmitter {
 
     _linkFadeTimeout: TimeoutID;
 
-    _pauseTimeout: TimeoutID;
-
     _willHideControls: Function;
 
     _hideControls: Function;
@@ -359,7 +357,6 @@ export default class BaseRenderer extends EventEmitter {
             logger.warn(e, 'error clearing behaviour elements');
         }
         clearInterval(this._timedEventsInterval);
-        if (this._pauseTimeout) clearTimeout(this._pauseTimeout);
         this._reapplyLinkConditions();
         this._player.exitCompleteBehaviourPhase();
         this._player.removeListener(PlayerEvents.LINK_CHOSEN, this._handleLinkChoiceEvent);
@@ -473,7 +470,6 @@ export default class BaseRenderer extends EventEmitter {
 
         // if we're in a pause behaviour, kill it
         if (this.getInPause()) {
-            if (this._pauseTimeout) clearTimeout(this._pauseTimeout);
             this.setInPause(false);
         }
 

--- a/src/renderers/BaseRenderer.js
+++ b/src/renderers/BaseRenderer.js
@@ -78,8 +78,6 @@ export default class BaseRenderer extends EventEmitter {
 
     _applyLinkOutBehaviour: Function;
 
-    _applyPauseBehaviour: Function;
-
     _handleLinkChoiceEvent: Function;
 
     _seekForward: Function;
@@ -179,7 +177,6 @@ export default class BaseRenderer extends EventEmitter {
         this._applyFadeOutBehaviour = this._applyFadeOutBehaviour.bind(this);
         this._applyFadeAudioOutBehaviour = this._applyFadeAudioOutBehaviour.bind(this);
         this._applyFadeAudioInBehaviour = this._applyFadeAudioInBehaviour.bind(this);
-        this._applyPauseBehaviour = this._applyPauseBehaviour.bind(this);
         this._seekBack = this._seekBack.bind(this);
         this._seekForward = this._seekForward.bind(this);
         this._handlePlayPauseButtonClicked = this._handlePlayPauseButtonClicked.bind(this);
@@ -217,8 +214,6 @@ export default class BaseRenderer extends EventEmitter {
             'urn:x-object-based-media:representation-behaviour:fadeaudioout/v1.0' : this._applyFadeAudioOutBehaviour,
             // eslint-disable-next-line max-len
             'urn:x-object-based-media:representation-behaviour:fadeaudioin/v1.0' : this._applyFadeAudioInBehaviour,
-            // eslint-disable-next-line max-len
-            'urn:x-object-based-media:representation-behaviour:pause/v1.0' : this._applyPauseBehaviour,
         };
 
         this._behaviourClassMap = {
@@ -1276,17 +1271,6 @@ export default class BaseRenderer extends EventEmitter {
         logger.warn(`${this._representation.type} representations do not support audio fade in`);
     }
 
-    _applyPauseBehaviour(behaviour: Object, callback: () => mixed) {
-        const { pauseTime } = behaviour;
-        this.pause();
-        this.setInPause(true);
-        this._pauseTimeout = setTimeout(() => {
-            this.play();
-            this.setInPause(false);
-            callback();
-        }, pauseTime*1000);
-    }
-
     // REFACTOR note: these are called by the behaviour, without knowing what will happen
     // via behaviour map
     _applyShowImageBehaviour(behaviour: Object, callback: () => mixed) {
@@ -1444,8 +1428,10 @@ export default class BaseRenderer extends EventEmitter {
         return false;
     }
 
-    // the renderer is waiting in an infinite pause behaviour
+    // set the renderer in/out of a pause behaviour
     setInPause(paused: boolean) {
+        if (paused) this.pause();
+        else this.play();
         this._inPauseBehaviourState = paused;
     }
 

--- a/src/renderers/BaseRenderer.js
+++ b/src/renderers/BaseRenderer.js
@@ -318,6 +318,11 @@ export default class BaseRenderer extends EventEmitter {
             return false;
         }
 
+        // init the behaviour runner, which will run completed behaviours
+        this._behaviourRunner = this._representation.behaviours ?
+            new BehaviourRunner(this._representation.behaviours, this) :
+            null;
+        
         this.emit(RendererEvents.CONSTRUCTED);
 
         this._player.setCurrentRenderer(this);


### PR DESCRIPTION
# Details
* Completed behaviours now run.  They had stopped when we removed during behaviours because the behaviour runner was initiated in the starting code.
* Implemented `pause` behaviour as a during behaviour.  Note that it cannot work as before in tandem with a show image or other during behaviours, as the timings of these are based on playhead time, so a pause of 2s at 2s will pause at 2s for 2s, but a parallel showimage of 2s with duration 2s will start at 2s but only disappear when the playhead reaches 4s.

# Ticket / issue URL
Ticket / issue URL: https://jira.dev.bbc.co.uk/browse/PRODTOOLS-3768

# PR Checks
(tick as appropriate) 

- [x] PR is linked to ticket / issue
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [x] PR has the package.json version bumped 
