### PR TITLE
fix: corrects webpack image file handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/storyplayer",
-  "version": "1.1.48",
+  "version": "1.1.49",
   "description": "StoryPlayer - reference player for BBC Research & Development's object-based media schema (https://www.npmjs.com/package/@bbc/object-based-media-schema)",
   "main": "dist/storyplayer.js",
   "keywords": [
@@ -55,7 +55,6 @@
     "eslint-plugin-babel": "^5.3.1",
     "eslint-plugin-flowtype": "^4.5.3",
     "eslint-plugin-import": "^2.22.1",
-    "file-loader": "^6.2.0",
     "flow-bin": "^0.114.0",
     "flow-typed": "^3.8.0",
     "javascript-obfuscator": "^4.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,25 +48,17 @@ module.exports = env => {
             },
             {
                 test: /\.(jpe?g|png|gif|svg)$/,
-                use: [
-                    {
-                        loader: 'file-loader',
-                        options: {
-                            name: 'images/[name].[ext]'
-                        }
-                    }
-                ]
+                type: 'asset/resource',
+                generator: {
+                    filename: 'images/[base]',
+                }
             },
             {
                 test: /\.(eot|ttf|woff|woff2)$/,
-                use: [
-                    {
-                        loader: 'file-loader',
-                        options: {
-                            name: 'fonts/[name].[ext]'
-                        }
-                    }
-                ]
+                type: 'asset/resource',
+                generator: {
+                    filename: 'fonts/[base]',
+                }
             }
             ]
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3934,14 +3934,6 @@ file-entry-cache@^6.0.1:
   dependencies:
     flat-cache "^3.0.4"
 
-file-loader@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.npmjs.org/file-loader/-/file-loader-6.2.0.tgz"
-  integrity sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^3.0.0"
-
 fill-range@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz"


### PR DESCRIPTION
# Details
Fixes the webpack config so that images are stored in the dist/images folder with original filenames.  Uses new [Asset Modules](https://webpack.js.org/guides/asset-modules/) and removes `file-loader`.

Version bumped to `1.1.49`

# Ticket / issue URL
Ticket / issue URL: https://jira.dev.bbc.co.uk/browse/PRODTOOLS-3779

# PR Checks
(tick as appropriate) 

- [x] PR is linked to ticket / issue
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [x] PR has the package.json version bumped 
