### PR TITLE
Fix: Try and get aroud CORS issue when requesting unpublished TTML subtitles

### DIFF
--- a/src/playoutEngines/SMPPlayoutEngine.js
+++ b/src/playoutEngines/SMPPlayoutEngine.js
@@ -170,8 +170,15 @@ class SMPPlayoutEngine extends BasePlayoutEngine {
         // Check if we have subtitles and that they are EBU-TT-D and not WebVTT
         if(
             "subs_url" in this._media[rendererId].media
-        ) { 
-            const subsAreEbuttFormat = await fetch(this._media[rendererId].media.subs_url)
+        ) {
+            // eslint-disable-next-line no-restricted-globals
+            const isPublishedExperience = parent.location.href.includes('/experience/');
+            const subsAreEbuttFormat = await fetch(
+                this._media[rendererId].media.subs_url,
+                {
+                    credentials: isPublishedExperience ? "same-origin": "include"
+                }
+            )
                 .then(res => res.text())
                 .then(text => text.includes('xmlns="http://www.w3.org/ns/ttml"')); // is this too much?  too little?
             if (subsAreEbuttFormat) playlistItem.captionsUrl = this._media[rendererId].media.subs_url;


### PR DESCRIPTION
I'm not sure where the SMPPlayoutEngine is executing from, either in the top level window, or an iFrame, so I don't know if it should be `parent.location` or `window.location` - any guidance would be appreciated

# Details
Brief description of what this PR does. 

# Ticket / issue URL
Ticket / issue URL: 

# PR Checks
(tick as appropriate) 

- [ ] PR is linked to ticket / issue
- [ ] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [ ] PR has the package.json version bumped 
