### PR TITLE
fix: replaces deprecated deg to rad conversion to fix 360 playback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/storyplayer",
-  "version": "1.1.50",
+  "version": "1.1.51",
   "description": "StoryPlayer - reference player for BBC Research & Development's object-based media schema (https://www.npmjs.com/package/@bbc/object-based-media-schema)",
   "main": "dist/storyplayer.js",
   "keywords": [

--- a/src/renderers/ThreeJSDriver.js
+++ b/src/renderers/ThreeJSDriver.js
@@ -171,8 +171,8 @@ export default class ThreeJSDriver {
 
         this._update = () => {
             const lat = Math.max(-85, Math.min(85, this._view.lat));
-            const phi = THREE.Math.degToRad(90 - lat);
-            const theta = THREE.Math.degToRad(this._view.lon);
+            const phi = (90 - lat) * (Math.PI / 180);
+            const theta = this._view.lon * (Math.PI / 180);
             const viewTarget = new THREE.Vector3(
                 this._view.distance * Math.sin(phi) * Math.cos(theta),
                 this._view.distance * Math.cos(phi),
@@ -383,9 +383,8 @@ export default class ThreeJSDriver {
         const { lat, long, radius } = position;
         const { width, height } = size;
         logger.info(`Adding threejs icon for ${targetId}, src ${iconSrc}, at (${lat}, ${long})`);
-
-        const vphi = THREE.Math.degToRad(90 - lat);
-        const vtheta = THREE.Math.degToRad(long);
+        const vphi = (90 - lat)  * (Math.PI / 180);
+        const vtheta = long * (Math.PI / 180);
         const xpos = radius * Math.sin(vphi) * Math.cos(vtheta);
         const ypos = radius * Math.cos(vphi);
         const zpos = radius * Math.sin(vphi) * Math.sin(vtheta);


### PR DESCRIPTION
# Details
Removes uses of the deprecated `THREE.Math.degToRad`, and does the calculations manually

# Ticket / issue URL
Ticket / issue URL:  https://jira.dev.bbc.co.uk/browse/PRODTOOLS-3802

# PR Checks
(tick as appropriate) 

- [x] PR is linked to ticket / issue
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [ ] PR has the package.json version bumped 
