### PR TITLE
fix: starts when ui enabled as long as renderer constructed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/storyplayer",
-  "version": "1.1.51",
+  "version": "1.1.52",
   "description": "StoryPlayer - reference player for BBC Research & Development's object-based media schema (https://www.npmjs.com/package/@bbc/object-based-media-schema)",
   "main": "dist/storyplayer.js",
   "keywords": [

--- a/src/gui/Player.js
+++ b/src/gui/Player.js
@@ -922,6 +922,7 @@ class Player extends EventEmitter {
         // in MAIN, or (for untimed representations) in MEDIA_FINISHED
         const startNow = (this._currentRenderer
             && (this._currentRenderer.phase === RENDERER_PHASES.MAIN
+            || this._currentRenderer.phase === RENDERER_PHASES.CONSTRUCTED
             || this._currentRenderer.phase === RENDERER_PHASES.MEDIA_FINISHED));
 
         if (startNow) this._controls.setControlsActive();

--- a/src/gui/Player.js
+++ b/src/gui/Player.js
@@ -54,6 +54,7 @@ const PlayerEvents = [
     'REPEAT_BUTTON_CLICKED',
     'LINK_CHOSEN',
     'ERROR_SKIP_BUTTON_CLICKED',
+    'START_BUTTON_CLICKED',
 ].reduce((events, eventName) => {
     // eslint-disable-next-line no-param-reassign
     events[eventName] = eventName;
@@ -922,7 +923,6 @@ class Player extends EventEmitter {
         // in MAIN, or (for untimed representations) in MEDIA_FINISHED
         const startNow = (this._currentRenderer
             && (this._currentRenderer.phase === RENDERER_PHASES.MAIN
-            || this._currentRenderer.phase === RENDERER_PHASES.CONSTRUCTED
             || this._currentRenderer.phase === RENDERER_PHASES.MEDIA_FINISHED));
 
         if (startNow) this._controls.setControlsActive();
@@ -939,7 +939,7 @@ class Player extends EventEmitter {
         }
 
         this._logUserInteraction(AnalyticEvents.names.START_BUTTON_CLICKED);
-        this.emit(PlayerEvents.PLAY_PAUSE_BUTTON_CLICKED);
+        this.emit(PlayerEvents.START_BUTTON_CLICKED);
     }
 
     _handleOverlayClick(event: Object) {

--- a/src/playoutEngines/DOMSwitchPlayoutEngine.js
+++ b/src/playoutEngines/DOMSwitchPlayoutEngine.js
@@ -132,6 +132,11 @@ export default class DOMSwitchPlayoutEngine extends BasePlayoutEngine {
         this._printActiveMSEBuffers = this._printActiveMSEBuffers.bind(this);
 
         this._player.on(
+            PlayerEvents.START_BUTTON_CLICKED,
+            this._handlePlayPauseButtonClicked,
+        );
+
+        this._player.on(
             PlayerEvents.PLAY_PAUSE_BUTTON_CLICKED,
             this._handlePlayPauseButtonClicked,
         );

--- a/src/playoutEngines/SMPPlayoutEngine.js
+++ b/src/playoutEngines/SMPPlayoutEngine.js
@@ -63,6 +63,7 @@ class SMPPlayoutEngine extends BasePlayoutEngine {
         this._volume = 1;
         this._backgroundMix = 1;
 
+        this._handleStartButtonClicked = this._handleStartButtonClicked.bind(this);
         this._handleVolumePersistence = this._handleVolumePersistence.bind(this);
         this._handleVolumeChange = this._handleVolumeChange.bind(this);
         this._smpPlayerInterface.addEventListener("volumechange", this._handleVolumeChange);
@@ -73,6 +74,10 @@ class SMPPlayoutEngine extends BasePlayoutEngine {
         this._player.on(
             PlayerEvents.VOLUME_CHANGED,
             this._handleVolumePersistence,
+        );
+        this._player.on(
+            PlayerEvents.START_BUTTON_CLICKED,
+            this._handleStartButtonClicked,
         );
     }
 
@@ -317,6 +322,10 @@ class SMPPlayoutEngine extends BasePlayoutEngine {
         }
         super.setPlayoutActive(rendererId)
         logger.info(`SMP-SP setPlayoutActive: ${rendererId}`)
+    }
+
+    _handleStartButtonClicked() {
+        this._playing = true;
     }
 
     _smpFakePlay() {

--- a/src/playoutEngines/iOSPlayoutEngine.js
+++ b/src/playoutEngines/iOSPlayoutEngine.js
@@ -67,6 +67,11 @@ export default class iOSPlayoutEngine extends BasePlayoutEngine {
         this.removeBackgrounds = this.removeBackgrounds.bind(this);
 
         this._player.on(
+            PlayerEvents.START_BUTTON_CLICKED,
+            this._handlePlayPauseButtonClicked,
+        );
+
+        this._player.on(
             PlayerEvents.PLAY_PAUSE_BUTTON_CLICKED,
             this._handlePlayPauseButtonClicked,
         );


### PR DESCRIPTION
# Details
In SMP player, restart (from saved state) did not work with timed images.  This meant that Out Late did not work on the second (or subsequent) play through on PX.  This is a fix

# Ticket / issue URL
Ticket / issue URL: https://jira.dev.bbc.co.uk/browse/PRODTOOLS-3806

# PR Checks
(tick as appropriate) 

- [x] PR is linked to ticket / issue
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [x] PR has the package.json version bumped 
