### PR TITLE
fix: replace bbc artifactory references with npm registry

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4,7 +4,7 @@
 
 "@ampproject/remapping@^2.1.0":
   version "2.2.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@ampproject/remapping/-/remapping-2.2.0.tgz"
+  resolved "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz"
   integrity sha1-VsEzgkeA3jF0rtWraDTzAmeQFU0=
   dependencies:
     "@jridgewell/gen-mapping" "^0.1.0"
@@ -35,14 +35,14 @@
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.14.5":
   version "7.14.5"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@babel/code-frame/-/code-frame-7.14.5.tgz"
+  resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz"
   integrity sha1-I7CNdA6D9JxeWZRfvxtD6Au/Tts=
   dependencies:
     "@babel/highlight" "^7.14.5"
 
 "@babel/code-frame@^7.16.7", "@babel/code-frame@^7.18.6":
   version "7.18.6"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@babel/code-frame/-/code-frame-7.18.6.tgz"
+  resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz"
   integrity sha1-OyXTjIlgC6otzCGe36iKdOssQno=
   dependencies:
     "@babel/highlight" "^7.18.6"
@@ -54,12 +54,12 @@
 
 "@babel/compat-data@^7.18.8":
   version "7.18.8"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@babel/compat-data/-/compat-data-7.18.8.tgz"
+  resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.8.tgz"
   integrity sha1-JIP1ZfrKYHuFNVkOhOfeMj8ndk0=
 
 "@babel/core@^7.11.6", "@babel/core@^7.12.3":
   version "7.18.9"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@babel/core/-/core-7.18.9.tgz"
+  resolved "https://registry.npmjs.org/@babel/core/-/core-7.18.9.tgz"
   integrity sha1-gFRh+WfHf/RsdMoEYMz0/pM93Vk=
   dependencies:
     "@ampproject/remapping" "^2.1.0"
@@ -101,7 +101,7 @@
 
 "@babel/generator@^7.14.2", "@babel/generator@^7.15.4", "@babel/generator@^7.7.2":
   version "7.15.4"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@babel/generator/-/generator-7.15.4.tgz"
+  resolved "https://registry.npmjs.org/@babel/generator/-/generator-7.15.4.tgz"
   integrity sha1-hayxWaJnymMk+Xk5hpke4gIqBbA=
   dependencies:
     "@babel/types" "^7.15.4"
@@ -119,7 +119,7 @@
 
 "@babel/generator@^7.18.9":
   version "7.18.9"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@babel/generator/-/generator-7.18.9.tgz"
+  resolved "https://registry.npmjs.org/@babel/generator/-/generator-7.18.9.tgz"
   integrity sha1-aDN+nqgETW3caQ+ymsrjk1nMoKU=
   dependencies:
     "@babel/types" "^7.18.9"
@@ -153,7 +153,7 @@
 
 "@babel/helper-compilation-targets@^7.18.9":
   version "7.18.9"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.9.tgz"
+  resolved "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.9.tgz"
   integrity sha1-aeZPV7UkzePl/2zFqfSjh+5VY78=
   dependencies:
     "@babel/compat-data" "^7.18.8"
@@ -197,7 +197,7 @@
 
 "@babel/helper-environment-visitor@^7.18.9":
   version "7.18.9"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz"
+  resolved "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz"
   integrity sha1-DAzumzXSyhkEeHVoZbs1KEIvUb4=
 
 "@babel/helper-explode-assignable-expression@^7.12.13":
@@ -218,7 +218,7 @@
 
 "@babel/helper-function-name@^7.14.2", "@babel/helper-function-name@^7.15.4":
   version "7.15.4"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz"
+  resolved "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz"
   integrity sha1-hFdE2vxDgaSl+2r6bD02+Yp4frw=
   dependencies:
     "@babel/helper-get-function-arity" "^7.15.4"
@@ -227,7 +227,7 @@
 
 "@babel/helper-function-name@^7.18.9":
   version "7.18.9"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@babel/helper-function-name/-/helper-function-name-7.18.9.tgz"
+  resolved "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.18.9.tgz"
   integrity sha1-lA5ghKVd7oZ9M7Tkh9omdjZehrA=
   dependencies:
     "@babel/template" "^7.18.6"
@@ -235,7 +235,7 @@
 
 "@babel/helper-get-function-arity@^7.12.13", "@babel/helper-get-function-arity@^7.15.4":
   version "7.15.4"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz"
+  resolved "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz"
   integrity sha1-CYgYk0oTf854tTaj4BWGS+Hih5s=
   dependencies:
     "@babel/types" "^7.15.4"
@@ -250,14 +250,14 @@
 
 "@babel/helper-hoist-variables@^7.15.4":
   version "7.15.4"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz"
+  resolved "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz"
   integrity sha1-CZk6MlnA6Rj5nRBCYd/fwDPxeN8=
   dependencies:
     "@babel/types" "^7.15.4"
 
 "@babel/helper-hoist-variables@^7.18.6":
   version "7.18.6"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz"
+  resolved "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz"
   integrity sha1-1NLI+0uuqlxouZzIJFxWVU+SZng=
   dependencies:
     "@babel/types" "^7.18.6"
@@ -278,7 +278,7 @@
 
 "@babel/helper-module-imports@^7.18.6":
   version "7.18.6"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz"
+  resolved "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz"
   integrity sha1-Hj69u9CKrRQ3tCjFAgTbE8Wjym4=
   dependencies:
     "@babel/types" "^7.18.6"
@@ -299,7 +299,7 @@
 
 "@babel/helper-module-transforms@^7.18.9":
   version "7.18.9"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@babel/helper-module-transforms/-/helper-module-transforms-7.18.9.tgz"
+  resolved "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.18.9.tgz"
   integrity sha1-WhB5wAUTXtYnRC3zGkKIfoD8txI=
   dependencies:
     "@babel/helper-environment-visitor" "^7.18.9"
@@ -325,7 +325,7 @@
 
 "@babel/helper-plugin-utils@^7.14.5":
   version "7.14.5"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz"
+  resolved "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz"
   integrity sha1-WsgizpfuxGdBq3ClF5ceRDpwxak=
 
 "@babel/helper-remap-async-to-generator@^7.13.0":
@@ -356,7 +356,7 @@
 
 "@babel/helper-simple-access@^7.18.6":
   version "7.18.6"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@babel/helper-simple-access/-/helper-simple-access-7.18.6.tgz"
+  resolved "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.18.6.tgz"
   integrity sha1-1tj1H0rCl4Bo35NLVp8I8peIx+o=
   dependencies:
     "@babel/types" "^7.18.6"
@@ -370,14 +370,14 @@
 
 "@babel/helper-split-export-declaration@^7.12.13", "@babel/helper-split-export-declaration@^7.15.4":
   version "7.15.4"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz"
+  resolved "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz"
   integrity sha1-rsq5Lc2+9qEKo7YqsgSwhfd24lc=
   dependencies:
     "@babel/types" "^7.15.4"
 
 "@babel/helper-split-export-declaration@^7.18.6":
   version "7.18.6"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz"
+  resolved "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz"
   integrity sha1-c2eUm8dbIMbVpdSpe7ooJK6O8HU=
   dependencies:
     "@babel/types" "^7.18.6"
@@ -389,12 +389,12 @@
 
 "@babel/helper-validator-identifier@^7.14.0", "@babel/helper-validator-identifier@^7.14.5", "@babel/helper-validator-identifier@^7.14.9":
   version "7.15.7"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz"
+  resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz"
   integrity sha1-Ig35k7/pBKSmsCq08zhaXr9uI4k=
 
 "@babel/helper-validator-identifier@^7.18.6":
   version "7.18.6"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz"
+  resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz"
   integrity sha1-nJfjDTGyuMcqHQiYTyyptXTXoHY=
 
 "@babel/helper-validator-option@^7.12.17":
@@ -404,7 +404,7 @@
 
 "@babel/helper-validator-option@^7.18.6":
   version "7.18.6"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz"
+  resolved "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz"
   integrity sha1-vw0rWlCbHzNgmeT/NuGmOqXbTbg=
 
 "@babel/helper-wrap-function@^7.13.0":
@@ -428,7 +428,7 @@
 
 "@babel/helpers@^7.18.9":
   version "7.18.9"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@babel/helpers/-/helpers-7.18.9.tgz"
+  resolved "https://registry.npmjs.org/@babel/helpers/-/helpers-7.18.9.tgz"
   integrity sha1-S+87iT8lOh7O0EUWgk7elNz+f/k=
   dependencies:
     "@babel/template" "^7.18.6"
@@ -446,7 +446,7 @@
 
 "@babel/highlight@^7.14.5":
   version "7.14.5"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@babel/highlight/-/highlight-7.14.5.tgz"
+  resolved "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz"
   integrity sha1-aGGlLwOWZAUAH2qlNKAaJNmejNk=
   dependencies:
     "@babel/helper-validator-identifier" "^7.14.5"
@@ -455,7 +455,7 @@
 
 "@babel/highlight@^7.16.7", "@babel/highlight@^7.18.6":
   version "7.18.6"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@babel/highlight/-/highlight-7.18.6.tgz"
+  resolved "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz"
   integrity sha1-gRWGAek+JWN5Wty/vfXWS+Py7N8=
   dependencies:
     "@babel/helper-validator-identifier" "^7.18.6"
@@ -481,12 +481,12 @@
 
 "@babel/parser@^7.12.13", "@babel/parser@^7.14.2", "@babel/parser@^7.15.4", "@babel/parser@^7.7.0":
   version "7.15.7"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@babel/parser/-/parser-7.15.7.tgz"
+  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.15.7.tgz"
   integrity sha1-DD7UousHsWXfqFs8xFxyczTE7a4=
 
 "@babel/parser@^7.14.7", "@babel/parser@^7.18.6", "@babel/parser@^7.18.9":
   version "7.18.9"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@babel/parser/-/parser-7.18.9.tgz"
+  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.18.9.tgz"
   integrity sha1-8t3gxoLMwmSpqFle/QMKXMj9JTk=
 
 "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@^7.13.12":
@@ -747,7 +747,7 @@
 
 "@babel/plugin-syntax-typescript@^7.7.2":
   version "7.14.5"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.14.5.tgz"
+  resolved "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.14.5.tgz"
   integrity sha1-uCxs5HGxZbXOQgz5KRTW+0YiVxY=
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
@@ -1118,7 +1118,7 @@
 
 "@babel/template@^7.12.13", "@babel/template@^7.15.4":
   version "7.15.4"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@babel/template/-/template-7.15.4.tgz"
+  resolved "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz"
   integrity sha1-UYmNNdzz+qZwxO5q/P1RfuE58ZQ=
   dependencies:
     "@babel/code-frame" "^7.14.5"
@@ -1127,7 +1127,7 @@
 
 "@babel/template@^7.18.6":
   version "7.18.6"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@babel/template/-/template-7.18.6.tgz"
+  resolved "https://registry.npmjs.org/@babel/template/-/template-7.18.6.tgz"
   integrity sha1-EoP0mT4AuSnW4tPHL9yRaKKXejE=
   dependencies:
     "@babel/code-frame" "^7.18.6"
@@ -1159,7 +1159,7 @@
 
 "@babel/traverse@^7.18.9":
   version "7.18.9"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@babel/traverse/-/traverse-7.18.9.tgz"
+  resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.9.tgz"
   integrity sha1-3u/z6PG62XhodMsv7aei13qQT5g=
   dependencies:
     "@babel/code-frame" "^7.18.6"
@@ -1175,7 +1175,7 @@
 
 "@babel/traverse@^7.7.0", "@babel/traverse@^7.7.2":
   version "7.15.4"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@babel/traverse/-/traverse-7.15.4.tgz"
+  resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz"
   integrity sha1-/4UQNnoUS/v/VS2eGOKPPiiJwi0=
   dependencies:
     "@babel/code-frame" "^7.14.5"
@@ -1198,7 +1198,7 @@
 
 "@babel/types@^7.12.13", "@babel/types@^7.14.2", "@babel/types@^7.15.4", "@babel/types@^7.7.0":
   version "7.15.6"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@babel/types/-/types-7.15.6.tgz"
+  resolved "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz"
   integrity sha1-mavcSCGLKIHAWN0KerBbmcm+dY8=
   dependencies:
     "@babel/helper-validator-identifier" "^7.14.9"
@@ -1206,7 +1206,7 @@
 
 "@babel/types@^7.18.6", "@babel/types@^7.18.9":
   version "7.18.9"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@babel/types/-/types-7.18.9.tgz"
+  resolved "https://registry.npmjs.org/@babel/types/-/types-7.18.9.tgz"
   integrity sha1-cUjWS6Ez2Nc6QbMXKsS4OhRSIF8=
   dependencies:
     "@babel/helper-validator-identifier" "^7.18.6"
@@ -1252,7 +1252,7 @@
 
 "@discoveryjs/json-ext@^0.5.0":
   version "0.5.7"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz"
+  resolved "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz"
   integrity sha1-HVcr+74Ut3BOC6Dzm3SBW4SHDXA=
 
 "@eslint/eslintrc@^0.4.1":
@@ -1288,7 +1288,7 @@
 
 "@javascript-obfuscator/escodegen@2.3.0":
   version "2.3.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@javascript-obfuscator/escodegen/-/escodegen-2.3.0.tgz#ff7eb7f8a7c004532e93b14ae8b2196dcf9a1a9e"
+  resolved "https://registry.npmjs.org/@javascript-obfuscator/escodegen/-/escodegen-2.3.0.tgz#ff7eb7f8a7c004532e93b14ae8b2196dcf9a1a9e"
   integrity sha1-/363+KfABFMuk7FK6LIZbc+aGp4=
   dependencies:
     "@javascript-obfuscator/estraverse" "^5.3.0"
@@ -1300,12 +1300,12 @@
 
 "@javascript-obfuscator/estraverse@5.4.0", "@javascript-obfuscator/estraverse@^5.3.0":
   version "5.4.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@javascript-obfuscator/estraverse/-/estraverse-5.4.0.tgz#6ddb28617356cfce9046a820f72af029f1bb5287"
+  resolved "https://registry.npmjs.org/@javascript-obfuscator/estraverse/-/estraverse-5.4.0.tgz#6ddb28617356cfce9046a820f72af029f1bb5287"
   integrity sha1-bdsoYXNWz86QRqgg9yrwKfG7Uoc=
 
 "@jest/console@^28.1.3":
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@jest/console/-/console-28.1.3.tgz"
+  resolved "https://registry.npmjs.org/@jest/console/-/console-28.1.3.tgz"
   integrity sha1-IDBgbsA6GMMYA7ijY4J2LkR2Vd8=
   dependencies:
     "@jest/types" "^28.1.3"
@@ -1317,7 +1317,7 @@
 
 "@jest/core@^28.1.3":
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@jest/core/-/core-28.1.3.tgz"
+  resolved "https://registry.npmjs.org/@jest/core/-/core-28.1.3.tgz"
   integrity sha1-Dr8r05hA8SM81fLR5vyLcb1aGsc=
   dependencies:
     "@jest/console" "^28.1.3"
@@ -1352,7 +1352,7 @@
 
 "@jest/environment@^28.1.3":
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@jest/environment/-/environment-28.1.3.tgz"
+  resolved "https://registry.npmjs.org/@jest/environment/-/environment-28.1.3.tgz"
   integrity sha1-q+1DprBApMJP3Laeqx+XWJstZj4=
   dependencies:
     "@jest/fake-timers" "^28.1.3"
@@ -1362,14 +1362,14 @@
 
 "@jest/expect-utils@^28.1.3":
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@jest/expect-utils/-/expect-utils-28.1.3.tgz"
+  resolved "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-28.1.3.tgz"
   integrity sha1-WFYc5dt80lOn7d28BR+zndpQ9SU=
   dependencies:
     jest-get-type "^28.0.2"
 
 "@jest/expect@^28.1.3":
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@jest/expect/-/expect-28.1.3.tgz"
+  resolved "https://registry.npmjs.org/@jest/expect/-/expect-28.1.3.tgz"
   integrity sha1-msV+HUSRuspVD2vb0jJIcXetanI=
   dependencies:
     expect "^28.1.3"
@@ -1377,7 +1377,7 @@
 
 "@jest/fake-timers@^28.1.3":
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@jest/fake-timers/-/fake-timers-28.1.3.tgz"
+  resolved "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-28.1.3.tgz"
   integrity sha1-IwJVs60KPUl48dBvcGhbrqkcZA4=
   dependencies:
     "@jest/types" "^28.1.3"
@@ -1389,7 +1389,7 @@
 
 "@jest/globals@^28.1.3":
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@jest/globals/-/globals-28.1.3.tgz"
+  resolved "https://registry.npmjs.org/@jest/globals/-/globals-28.1.3.tgz"
   integrity sha1-pgHXjdxf3vVCcoMJiUiVtKQtwzM=
   dependencies:
     "@jest/environment" "^28.1.3"
@@ -1398,7 +1398,7 @@
 
 "@jest/reporters@^28.1.3":
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@jest/reporters/-/reporters-28.1.3.tgz"
+  resolved "https://registry.npmjs.org/@jest/reporters/-/reporters-28.1.3.tgz"
   integrity sha1-mt9tJl7a/F/EpDTPsx4t9aZ6Npo=
   dependencies:
     "@bcoe/v8-coverage" "^0.2.3"
@@ -1429,14 +1429,14 @@
 
 "@jest/schemas@^28.1.3":
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@jest/schemas/-/schemas-28.1.3.tgz"
+  resolved "https://registry.npmjs.org/@jest/schemas/-/schemas-28.1.3.tgz"
   integrity sha1-rYuGpm8R8zYZ49fh3N3X8tQP+QU=
   dependencies:
     "@sinclair/typebox" "^0.24.1"
 
 "@jest/source-map@^28.1.2":
   version "28.1.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@jest/source-map/-/source-map-28.1.2.tgz"
+  resolved "https://registry.npmjs.org/@jest/source-map/-/source-map-28.1.2.tgz"
   integrity sha1-f+gysXK0l9ZmPN/2wTsKkg4TniQ=
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.13"
@@ -1445,7 +1445,7 @@
 
 "@jest/test-result@^28.1.3":
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@jest/test-result/-/test-result-28.1.3.tgz"
+  resolved "https://registry.npmjs.org/@jest/test-result/-/test-result-28.1.3.tgz"
   integrity sha1-Xq6UX9n0uPz8500jnm9yW2vwdsU=
   dependencies:
     "@jest/console" "^28.1.3"
@@ -1455,7 +1455,7 @@
 
 "@jest/test-sequencer@^28.1.3":
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@jest/test-sequencer/-/test-sequencer-28.1.3.tgz"
+  resolved "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-28.1.3.tgz"
   integrity sha1-nQwoPZBqxZnHS95GS8DX5qgohsM=
   dependencies:
     "@jest/test-result" "^28.1.3"
@@ -1465,7 +1465,7 @@
 
 "@jest/transform@^28.1.3":
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@jest/transform/-/transform-28.1.3.tgz"
+  resolved "https://registry.npmjs.org/@jest/transform/-/transform-28.1.3.tgz"
   integrity sha1-WdgJjlCrB5UODy/A/H7EYjcSgbA=
   dependencies:
     "@babel/core" "^7.11.6"
@@ -1486,7 +1486,7 @@
 
 "@jest/types@^28.1.3":
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@jest/types/-/types-28.1.3.tgz"
+  resolved "https://registry.npmjs.org/@jest/types/-/types-28.1.3.tgz"
   integrity sha1-sF3oCZb/ElErxc6x0ggoWn0RdIs=
   dependencies:
     "@jest/schemas" "^28.1.3"
@@ -1498,7 +1498,7 @@
 
 "@jridgewell/gen-mapping@^0.1.0":
   version "0.1.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz"
+  resolved "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz"
   integrity sha1-5dLkUDBqlJHjvXfjI+ONev8xWZY=
   dependencies:
     "@jridgewell/set-array" "^1.0.0"
@@ -1506,7 +1506,7 @@
 
 "@jridgewell/gen-mapping@^0.3.0", "@jridgewell/gen-mapping@^0.3.2":
   version "0.3.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz"
+  resolved "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz"
   integrity sha1-wa7cYehT8rufXf5tRELTtWWyU7k=
   dependencies:
     "@jridgewell/set-array" "^1.0.1"
@@ -1515,17 +1515,17 @@
 
 "@jridgewell/resolve-uri@^3.0.3":
   version "3.1.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz"
+  resolved "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz"
   integrity sha1-IgOxGMFXchrd/mnUe3BGVGMGbXg=
 
 "@jridgewell/set-array@^1.0.0", "@jridgewell/set-array@^1.0.1":
   version "1.1.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@jridgewell/set-array/-/set-array-1.1.2.tgz"
+  resolved "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz"
   integrity sha1-fGz5mNbSC5FMClWpGuko/yWWXnI=
 
 "@jridgewell/source-map@^0.3.2":
   version "0.3.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@jridgewell/source-map/-/source-map-0.3.2.tgz"
+  resolved "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz"
   integrity sha1-9FNRqu1FJ6KYUS7HL4EEDJmFgPs=
   dependencies:
     "@jridgewell/gen-mapping" "^0.3.0"
@@ -1533,12 +1533,12 @@
 
 "@jridgewell/sourcemap-codec@^1.4.10":
   version "1.4.14"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz"
+  resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz"
   integrity sha1-rdTJjTQUcqKJGQtCTvvbCWmRuyQ=
 
 "@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.13", "@jridgewell/trace-mapping@^0.3.7", "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.14"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz"
+  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz"
   integrity sha1-sjGggdj2Z5bkda1Yih70cxEnAe0=
   dependencies:
     "@jridgewell/resolve-uri" "^3.0.3"
@@ -1563,14 +1563,14 @@
 
 "@octokit/auth-token@^2.4.4":
   version "2.5.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@octokit/auth-token/-/auth-token-2.5.0.tgz"
+  resolved "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz"
   integrity sha1-J8N+omwgXyhENAJHf/0mExHyHjY=
   dependencies:
     "@octokit/types" "^6.0.3"
 
 "@octokit/core@^3.5.1":
   version "3.6.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@octokit/core/-/core-3.6.0.tgz"
+  resolved "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz"
   integrity sha1-M3bLnzAI2bPREDcNkOCh/NX+YIU=
   dependencies:
     "@octokit/auth-token" "^2.4.4"
@@ -1583,7 +1583,7 @@
 
 "@octokit/endpoint@^6.0.1":
   version "6.0.12"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@octokit/endpoint/-/endpoint-6.0.12.tgz"
+  resolved "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz"
   integrity sha1-O01HpLDnmxAn+4111CIZKLLQVlg=
   dependencies:
     "@octokit/types" "^6.0.3"
@@ -1592,7 +1592,7 @@
 
 "@octokit/graphql@^4.5.8":
   version "4.8.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@octokit/graphql/-/graphql-4.8.0.tgz"
+  resolved "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz"
   integrity sha1-Zk2bEcDhIRLL944Q9JoFlZqiLMM=
   dependencies:
     "@octokit/request" "^5.6.0"
@@ -1601,24 +1601,24 @@
 
 "@octokit/openapi-types@^12.10.0":
   version "12.10.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@octokit/openapi-types/-/openapi-types-12.10.1.tgz"
+  resolved "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.10.1.tgz"
   integrity sha1-V7XMbHtOVdhkLJPQZAH7GvSDmJk=
 
 "@octokit/plugin-paginate-rest@^2.16.8":
   version "2.21.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.21.2.tgz"
+  resolved "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.21.2.tgz"
   integrity sha1-BwvpuxjLeOUrRx3cNVHSg1Xi1eI=
   dependencies:
     "@octokit/types" "^6.39.0"
 
 "@octokit/plugin-request-log@^1.0.4":
   version "1.0.4"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz"
+  resolved "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz"
   integrity sha1-XlDtcIOmE4FrHkooruxft/FGLoU=
 
 "@octokit/plugin-rest-endpoint-methods@^5.12.0":
   version "5.16.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.16.2.tgz"
+  resolved "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.16.2.tgz"
   integrity sha1-fui/WG35fdaGjPaPZBNU6QjCU0I=
   dependencies:
     "@octokit/types" "^6.39.0"
@@ -1626,7 +1626,7 @@
 
 "@octokit/request-error@^2.0.5", "@octokit/request-error@^2.1.0":
   version "2.1.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@octokit/request-error/-/request-error-2.1.0.tgz"
+  resolved "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz"
   integrity sha1-nhUDV4Mb/HiNE6T9SxkT1gx01nc=
   dependencies:
     "@octokit/types" "^6.0.3"
@@ -1635,7 +1635,7 @@
 
 "@octokit/request@^5.6.0", "@octokit/request@^5.6.3":
   version "5.6.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@octokit/request/-/request-5.6.3.tgz"
+  resolved "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz"
   integrity sha1-GaAiUVpbupZawGydEzRRTrUMSLA=
   dependencies:
     "@octokit/endpoint" "^6.0.1"
@@ -1647,7 +1647,7 @@
 
 "@octokit/rest@^18.12.0":
   version "18.12.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@octokit/rest/-/rest-18.12.0.tgz"
+  resolved "https://registry.npmjs.org/@octokit/rest/-/rest-18.12.0.tgz"
   integrity sha1-8GvElS/IcTAwjYEMqdAOefaYiIE=
   dependencies:
     "@octokit/core" "^3.5.1"
@@ -1657,19 +1657,19 @@
 
 "@octokit/types@^6.0.3", "@octokit/types@^6.16.1", "@octokit/types@^6.39.0":
   version "6.40.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@octokit/types/-/types-6.40.0.tgz"
+  resolved "https://registry.npmjs.org/@octokit/types/-/types-6.40.0.tgz"
   integrity sha1-8uZlGW1Bnhm7QmVgPPkEqCBQXQ4=
   dependencies:
     "@octokit/openapi-types" "^12.10.0"
 
 "@sinclair/typebox@^0.24.1":
   version "0.24.20"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@sinclair/typebox/-/typebox-0.24.20.tgz"
+  resolved "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.20.tgz"
   integrity sha1-EaZXh13mAIYi1T9W4GOmNHxRpt0=
 
 "@sindresorhus/is@^4.0.0":
   version "4.6.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@sindresorhus/is/-/is-4.6.0.tgz"
+  resolved "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz"
   integrity sha1-PHycRuZ4/u/nouW7YJ09vWZf+z8=
 
 "@sinonjs/commons@^1", "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0":
@@ -1681,7 +1681,7 @@
 
 "@sinonjs/fake-timers@^9.1.2":
   version "9.1.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz"
+  resolved "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz"
   integrity sha1-Tqq3N/q3czKrEy05ajwNNkvQ6ow=
   dependencies:
     "@sinonjs/commons" "^1.7.0"
@@ -1715,19 +1715,19 @@
 
 "@szmarczak/http-timer@^4.0.5":
   version "4.0.6"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@szmarczak/http-timer/-/http-timer-4.0.6.tgz"
+  resolved "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz"
   integrity sha1-tKkUu2LnwnLU5Zif5EQPgSqx2Ac=
   dependencies:
     defer-to-connect "^2.0.0"
 
 "@tootallnate/once@2":
   version "2.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
+  resolved "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha1-9UShSNOrNYAcH2M6dEH9h8LkhL8=
 
 "@types/babel__core@^7.1.14":
   version "7.1.16"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@types/babel__core/-/babel__core-7.1.16.tgz"
+  resolved "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.16.tgz"
   integrity sha1-vBLHS31l6C0ph2tdC69cYlrFhwI=
   dependencies:
     "@babel/parser" "^7.1.0"
@@ -1760,7 +1760,7 @@
 
 "@types/cacheable-request@^6.0.1":
   version "6.0.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@types/cacheable-request/-/cacheable-request-6.0.2.tgz"
+  resolved "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.2.tgz"
   integrity sha1-wyTaAZfeCpiiMSFWU2riYkKf9rk=
   dependencies:
     "@types/http-cache-semantics" "*"
@@ -1770,7 +1770,7 @@
 
 "@types/eslint-scope@^3.7.3":
   version "3.7.4"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@types/eslint-scope/-/eslint-scope-3.7.4.tgz"
+  resolved "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz"
   integrity sha1-N/wSI/B4bDlicGihLpTW5vxh3hY=
   dependencies:
     "@types/eslint" "*"
@@ -1778,7 +1778,7 @@
 
 "@types/eslint@*":
   version "8.4.5"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@types/eslint/-/eslint-8.4.5.tgz"
+  resolved "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.5.tgz"
   integrity sha1-rN+33Ta5HMXYEtfAk4Eajz2bMeQ=
   dependencies:
     "@types/estree" "*"
@@ -1786,24 +1786,24 @@
 
 "@types/estree@*":
   version "1.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@types/estree/-/estree-1.0.0.tgz"
+  resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz"
   integrity sha1-X7LlNsGum/NTZu7Yeegn+lnKQcI=
 
 "@types/estree@^0.0.51":
   version "0.0.51"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@types/estree/-/estree-0.0.51.tgz"
+  resolved "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz"
   integrity sha1-z9cJJKJaP9MrIY5eQg5ol+GsT0A=
 
 "@types/graceful-fs@^4.1.3":
   version "4.1.5"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@types/graceful-fs/-/graceful-fs-4.1.5.tgz"
+  resolved "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz"
   integrity sha1-If+6DZjaQ1DbZIkfkqnl2zzbThU=
   dependencies:
     "@types/node" "*"
 
 "@types/http-cache-semantics@*":
   version "4.0.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz"
+  resolved "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz"
   integrity sha1-Dqe2FJaQK5WJDcTDoRa2DLja6BI=
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
@@ -1827,7 +1827,7 @@
 
 "@types/jsdom@^16.2.4":
   version "16.2.14"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@types/jsdom/-/jsdom-16.2.14.tgz#26fe9da6a8870715b154bb84cd3b2e53433d8720"
+  resolved "https://registry.npmjs.org/@types/jsdom/-/jsdom-16.2.14.tgz#26fe9da6a8870715b154bb84cd3b2e53433d8720"
   integrity sha1-Jv6dpqiHBxWxVLuEzTsuU0M9hyA=
   dependencies:
     "@types/node" "*"
@@ -1836,12 +1836,12 @@
 
 "@types/json-buffer@~3.0.0":
   version "3.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@types/json-buffer/-/json-buffer-3.0.0.tgz"
+  resolved "https://registry.npmjs.org/@types/json-buffer/-/json-buffer-3.0.0.tgz"
   integrity sha1-hcH/DwlI/BWYENS1vjW/jCCHX2Q=
 
 "@types/json-schema@*", "@types/json-schema@^7.0.8":
   version "7.0.11"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@types/json-schema/-/json-schema-7.0.11.tgz"
+  resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz"
   integrity sha1-1CG2xSejA398hEM/0sQingFoY9M=
 
 "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.6":
@@ -1856,7 +1856,7 @@
 
 "@types/keyv@*":
   version "3.1.4"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@types/keyv/-/keyv-3.1.4.tgz"
+  resolved "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz"
   integrity sha1-PM2xxnUbDH5SMAvNrNW8v4+qdbY=
   dependencies:
     "@types/node" "*"
@@ -1873,17 +1873,17 @@
 
 "@types/parse5@*":
   version "6.0.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@types/parse5/-/parse5-6.0.3.tgz#705bb349e789efa06f43f128cef51240753424cb"
+  resolved "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz#705bb349e789efa06f43f128cef51240753424cb"
   integrity sha1-cFuzSeeJ76BvQ/EozvUSQHU0JMs=
 
 "@types/prettier@^2.1.5":
   version "2.3.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@types/prettier/-/prettier-2.3.2.tgz"
+  resolved "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.2.tgz"
   integrity sha1-/IwoJeTtIUJHO0qBBk5uCBRj0bM=
 
 "@types/responselike@*", "@types/responselike@^1.0.0":
   version "1.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@types/responselike/-/responselike-1.0.0.tgz"
+  resolved "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz"
   integrity sha1-JR9P59FU0rrRJavhtCmyOv0mLik=
   dependencies:
     "@types/node" "*"
@@ -1895,7 +1895,7 @@
 
 "@types/tough-cookie@*":
   version "4.0.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@types/tough-cookie/-/tough-cookie-4.0.2.tgz#6286b4c7228d58ab7866d19716f3696e03a09397"
+  resolved "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz#6286b4c7228d58ab7866d19716f3696e03a09397"
   integrity sha1-Yoa0xyKNWKt4ZtGXFvNpbgOgk5c=
 
 "@types/yargs-parser@*":
@@ -1905,14 +1905,14 @@
 
 "@types/yargs@^17.0.8":
   version "17.0.10"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@types/yargs/-/yargs-17.0.10.tgz"
+  resolved "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.10.tgz"
   integrity sha1-WRUi/Ohdhzm8p7i7kNBI5EeNGGo=
   dependencies:
     "@types/yargs-parser" "*"
 
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@webassemblyjs/ast/-/ast-1.11.1.tgz"
+  resolved "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz"
   integrity sha1-K/12fq4aaZb0Mv9+jX/HVnnAtqc=
   dependencies:
     "@webassemblyjs/helper-numbers" "1.11.1"
@@ -1920,22 +1920,22 @@
 
 "@webassemblyjs/floating-point-hex-parser@1.11.1":
   version "1.11.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz"
+  resolved "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz"
   integrity sha1-9sYacF8P16auyqToGY8j2dwXnk8=
 
 "@webassemblyjs/helper-api-error@1.11.1":
   version "1.11.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz"
+  resolved "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz"
   integrity sha1-GmMZLYeI5cASgAump6RscFKI/RY=
 
 "@webassemblyjs/helper-buffer@1.11.1":
   version "1.11.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz"
+  resolved "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz"
   integrity sha1-gyqQDrREiEzemnytRn+BUA9eWrU=
 
 "@webassemblyjs/helper-numbers@1.11.1":
   version "1.11.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz"
+  resolved "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz"
   integrity sha1-ZNgdohn7u6HjvRv8dPboxOEKYq4=
   dependencies:
     "@webassemblyjs/floating-point-hex-parser" "1.11.1"
@@ -1944,12 +1944,12 @@
 
 "@webassemblyjs/helper-wasm-bytecode@1.11.1":
   version "1.11.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz"
+  resolved "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz"
   integrity sha1-8ygkHkHnsZnQsgwY6IQpxEMyleE=
 
 "@webassemblyjs/helper-wasm-section@1.11.1":
   version "1.11.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz"
+  resolved "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz"
   integrity sha1-Ie4GWntjXzGec48N1zv72igcCXo=
   dependencies:
     "@webassemblyjs/ast" "1.11.1"
@@ -1959,26 +1959,26 @@
 
 "@webassemblyjs/ieee754@1.11.1":
   version "1.11.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz"
+  resolved "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz"
   integrity sha1-ljkp6bvQVwnn4SJDoJkYCBKZJhQ=
   dependencies:
     "@xtuc/ieee754" "^1.2.0"
 
 "@webassemblyjs/leb128@1.11.1":
   version "1.11.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@webassemblyjs/leb128/-/leb128-1.11.1.tgz"
+  resolved "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz"
   integrity sha1-zoFLRVdOk9drrh+yZEq5zdlSeqU=
   dependencies:
     "@xtuc/long" "4.2.2"
 
 "@webassemblyjs/utf8@1.11.1":
   version "1.11.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@webassemblyjs/utf8/-/utf8-1.11.1.tgz"
+  resolved "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz"
   integrity sha1-0fi3ZDaefG5rrjUOhU3smlnwo/8=
 
 "@webassemblyjs/wasm-edit@1.11.1":
   version "1.11.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz"
+  resolved "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz"
   integrity sha1-rSBuv0v5WgWM6YgKjAksXeyBk9Y=
   dependencies:
     "@webassemblyjs/ast" "1.11.1"
@@ -1992,7 +1992,7 @@
 
 "@webassemblyjs/wasm-gen@1.11.1":
   version "1.11.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz"
+  resolved "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz"
   integrity sha1-hsXqMEhJdZt9iMR6MvTwOa48j3Y=
   dependencies:
     "@webassemblyjs/ast" "1.11.1"
@@ -2003,7 +2003,7 @@
 
 "@webassemblyjs/wasm-opt@1.11.1":
   version "1.11.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz"
+  resolved "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz"
   integrity sha1-ZXtMIgL0zzs0X4pMZGHIwkGJhfI=
   dependencies:
     "@webassemblyjs/ast" "1.11.1"
@@ -2013,7 +2013,7 @@
 
 "@webassemblyjs/wasm-parser@1.11.1":
   version "1.11.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz"
+  resolved "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz"
   integrity sha1-hspzRTT0F+m9PGfHocddi+QfsZk=
   dependencies:
     "@webassemblyjs/ast" "1.11.1"
@@ -2025,7 +2025,7 @@
 
 "@webassemblyjs/wast-printer@1.11.1":
   version "1.11.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz"
+  resolved "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz"
   integrity sha1-0Mc77ajuxUJvEK6O9VzuXnCEwvA=
   dependencies:
     "@webassemblyjs/ast" "1.11.1"
@@ -2033,19 +2033,19 @@
 
 "@webpack-cli/configtest@^1.2.0":
   version "1.2.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@webpack-cli/configtest/-/configtest-1.2.0.tgz"
+  resolved "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.2.0.tgz"
   integrity sha1-eyDOHBJTORLDshfqaCYjZfoppvU=
 
 "@webpack-cli/info@^1.5.0":
   version "1.5.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@webpack-cli/info/-/info-1.5.0.tgz"
+  resolved "https://registry.npmjs.org/@webpack-cli/info/-/info-1.5.0.tgz"
   integrity sha1-bHjBPFh0hS1uLdF/CKQfP+TCYbE=
   dependencies:
     envinfo "^7.7.3"
 
 "@webpack-cli/serve@^1.7.0":
   version "1.7.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/@webpack-cli/serve/-/serve-1.7.0.tgz"
+  resolved "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.7.0.tgz"
   integrity sha1-4Zk2iaxC0rFukZQ3bPtnU/YlTbE=
 
 "@xtuc/ieee754@^1.2.0":
@@ -2065,17 +2065,17 @@ abab@^2.0.5:
 
 abab@^2.0.6:
   version "2.0.6"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
+  resolved "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
   integrity sha1-QbgPLIcdGWhiFrgjCSMc/Tyz0pE=
 
 ace-builds@^1.6.0:
   version "1.7.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/ace-builds/-/ace-builds-1.7.1.tgz"
+  resolved "https://registry.npmjs.org/ace-builds/-/ace-builds-1.7.1.tgz"
   integrity sha1-vnlvvZhhDdpeE4rtmNMJysKrCHI=
 
 acorn-globals@^6.0.0:
   version "6.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/acorn-globals/-/acorn-globals-6.0.0.tgz#46cdd39f0f8ff08a876619b55f5ac8a6dc770b45"
+  resolved "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz#46cdd39f0f8ff08a876619b55f5ac8a6dc770b45"
   integrity sha1-Rs3Tnw+P8IqHZhm1X1rIptx3C0U=
   dependencies:
     acorn "^7.1.1"
@@ -2083,7 +2083,7 @@ acorn-globals@^6.0.0:
 
 acorn-import-assertions@^1.7.6:
   version "1.8.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz"
+  resolved "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz"
   integrity sha1-uitZOc5iwjjbbZPYHJsRGym4Vek=
 
 acorn-jsx@^3.0.0:
@@ -2100,12 +2100,12 @@ acorn-jsx@^5.3.1:
 
 acorn-walk@^7.1.1:
   version "7.2.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
+  resolved "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha1-DeiJpgEgOQmw++B7iTjcIdLpZ7w=
 
 acorn@8.7.0:
   version "8.7.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
+  resolved "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
   integrity sha1-kJUf3g+PCd+TVJSB5fwUFEW3kc8=
 
 acorn@^3.0.4:
@@ -2125,12 +2125,12 @@ acorn@^7.1.1, acorn@^7.4.0:
 
 acorn@^8.4.1, acorn@^8.5.0:
   version "8.7.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/acorn/-/acorn-8.7.1.tgz"
+  resolved "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz"
   integrity sha1-AZcSLIQ9G/bQpegyIKeI8nj2PDA=
 
 agent-base@6:
   version "6.0.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  resolved "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
   integrity sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=
   dependencies:
     debug "4"
@@ -2217,7 +2217,7 @@ ansi-regex@^5.0.0:
 
 ansi-regex@^5.0.1:
   version "5.0.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/ansi-regex/-/ansi-regex-5.0.1.tgz"
+  resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz"
   integrity sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=
 
 ansi-styles@^2.2.1:
@@ -2227,7 +2227,7 @@ ansi-styles@^2.2.1:
 
 ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/ansi-styles/-/ansi-styles-3.2.1.tgz"
+  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz"
   integrity sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=
   dependencies:
     color-convert "^1.9.0"
@@ -2241,7 +2241,7 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
 
 ansi-styles@^5.0.0:
   version "5.2.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/ansi-styles/-/ansi-styles-5.2.0.tgz"
+  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz"
   integrity sha1-B0SWkK1Fd30ZJKwquy/IiV26g2s=
 
 anymatch@^2.0.0:
@@ -2324,7 +2324,7 @@ arrify@^2.0.1:
 
 assert@2.0.0:
   version "2.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/assert/-/assert-2.0.0.tgz#95fc1c616d48713510680f2eaf2d10dd22e02d32"
+  resolved "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz#95fc1c616d48713510680f2eaf2d10dd22e02d32"
   integrity sha1-lfwcYW1IcTUQaA8ury0Q3SLgLTI=
   dependencies:
     es6-object-assign "^1.1.0"
@@ -2354,7 +2354,7 @@ async-each@^1.0.1:
 
 asynckit@^0.4.0:
   version "0.4.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
 atob@^2.1.2:
@@ -2364,12 +2364,12 @@ atob@^2.1.2:
 
 available-typed-arrays@^1.0.5:
   version "1.0.5"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
+  resolved "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha1-kvlWFlAQadB9EO2y/DfT4cZRI7c=
 
 babel-eslint@^10.1.0:
   version "10.1.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/babel-eslint/-/babel-eslint-10.1.0.tgz"
+  resolved "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz"
   integrity sha1-aWjlaKkQt4+zd5zdi2rC9HmUMjI=
   dependencies:
     "@babel/code-frame" "^7.0.0"
@@ -2381,7 +2381,7 @@ babel-eslint@^10.1.0:
 
 babel-jest@^28.1.3:
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/babel-jest/-/babel-jest-28.1.3.tgz"
+  resolved "https://registry.npmjs.org/babel-jest/-/babel-jest-28.1.3.tgz"
   integrity sha1-wRhyWBl8CZByFWoKEhwR7h45F9U=
   dependencies:
     "@jest/transform" "^28.1.3"
@@ -2411,7 +2411,7 @@ babel-plugin-dynamic-import-node@^2.3.3:
 
 babel-plugin-istanbul@^6.1.1:
   version "6.1.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz"
+  resolved "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz"
   integrity sha1-+ojsWSMv2bTjbbvFQKjsmptH2nM=
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
@@ -2422,7 +2422,7 @@ babel-plugin-istanbul@^6.1.1:
 
 babel-plugin-jest-hoist@^28.1.3:
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-28.1.3.tgz"
+  resolved "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-28.1.3.tgz"
   integrity sha1-GVLE0OpQ8tbXlDU3YieNHYzKP74=
   dependencies:
     "@babel/template" "^7.3.3"
@@ -2474,7 +2474,7 @@ babel-preset-current-node-syntax@^1.0.0:
 
 babel-preset-jest@^28.1.3:
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/babel-preset-jest/-/babel-preset-jest-28.1.3.tgz"
+  resolved "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-28.1.3.tgz"
   integrity sha1-XfwguZq+1duZRAbCuauUxzqqQZ0=
   dependencies:
     babel-plugin-jest-hoist "^28.1.3"
@@ -2500,7 +2500,7 @@ base@^0.11.1:
 
 before-after-hook@^2.2.0:
   version "2.2.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/before-after-hook/-/before-after-hook-2.2.2.tgz"
+  resolved "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz"
   integrity sha1-pujKQQKNkO4sJCIvIByQlWCRYT4=
 
 big.js@^5.2.2:
@@ -2561,7 +2561,7 @@ browser-bunyan@^1.5.3:
 
 browser-process-hrtime@^1.0.0:
   version "1.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
+  resolved "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
   integrity sha1-PJtLfXgsgSHlbxAQbYTA0P/JRiY=
 
 browserslist@^4.14.5, browserslist@^4.16.6:
@@ -2577,7 +2577,7 @@ browserslist@^4.14.5, browserslist@^4.16.6:
 
 browserslist@^4.20.2:
   version "4.21.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/browserslist/-/browserslist-4.21.2.tgz"
+  resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.21.2.tgz"
   integrity sha1-WaQAdXRlU1lUlGpAC4Qe034rTs8=
   dependencies:
     caniuse-lite "^1.0.30001366"
@@ -2614,12 +2614,12 @@ cache-base@^1.0.1:
 
 cacheable-lookup@^5.0.3:
   version "5.0.4"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz"
+  resolved "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz"
   integrity sha1-WmuGWyxENXvj1evCpGewMnGacAU=
 
 cacheable-request@^7.0.2:
   version "7.0.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/cacheable-request/-/cacheable-request-7.0.2.tgz"
+  resolved "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz"
   integrity sha1-6g0LiJNkolhUdXMByhKy2nf5HSc=
   dependencies:
     clone-response "^1.0.2"
@@ -2662,7 +2662,7 @@ camelcase@^5.0.0, camelcase@^5.3.1:
 
 camelcase@^6.2.0:
   version "6.2.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/camelcase/-/camelcase-6.2.0.tgz"
+  resolved "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz"
   integrity sha1-kkr4gcnVJaydh/QNlk5c6pgqGAk=
 
 caniuse-lite@^1.0.30001219:
@@ -2672,7 +2672,7 @@ caniuse-lite@^1.0.30001219:
 
 caniuse-lite@^1.0.30001366:
   version "1.0.30001367"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/caniuse-lite/-/caniuse-lite-1.0.30001367.tgz"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001367.tgz"
   integrity sha1-K5f+Ry6Popx4xZcGFdfNLuQUEIo=
 
 chai@^4.2.0:
@@ -2689,7 +2689,7 @@ chai@^4.2.0:
 
 chalk@4.1.2:
   version "4.1.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=
   dependencies:
     ansi-styles "^4.1.0"
@@ -2708,7 +2708,7 @@ chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
 
 chalk@^2.0.0, chalk@^2.4.2:
   version "2.4.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/chalk/-/chalk-2.4.2.tgz"
+  resolved "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz"
   integrity sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=
   dependencies:
     ansi-styles "^3.2.1"
@@ -2725,7 +2725,7 @@ chalk@^4.0.0:
 
 chance@1.1.8:
   version "1.1.8"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/chance/-/chance-1.1.8.tgz#5d6c2b78c9170bf6eb9df7acdda04363085be909"
+  resolved "https://registry.npmjs.org/chance/-/chance-1.1.8.tgz#5d6c2b78c9170bf6eb9df7acdda04363085be909"
   integrity sha1-XWwreMkXC/brnfes3aBDYwhb6Qk=
 
 char-regex@^1.0.2:
@@ -2745,7 +2745,7 @@ check-error@^1.0.2:
 
 "chokidar@>=3.0.0 <4.0.0":
   version "3.5.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
+  resolved "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
   integrity sha1-HPN8hwe5Mr0a8a4iwEMuKs0ZA70=
   dependencies:
     anymatch "~3.1.2"
@@ -2780,7 +2780,7 @@ chrome-trace-event@^1.0.2:
 
 ci-info@^3.2.0:
   version "3.3.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/ci-info/-/ci-info-3.3.2.tgz"
+  resolved "https://registry.npmjs.org/ci-info/-/ci-info-3.3.2.tgz"
   integrity sha1-bSln/6QHRmSBxskLbhazCY8IASg=
 
 circular-json@^0.3.1:
@@ -2790,7 +2790,7 @@ circular-json@^0.3.1:
 
 cjs-module-lexer@^1.0.0:
   version "1.2.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz"
+  resolved "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz"
   integrity sha1-n4S6MkSlEvOlTlJ36O70xImGTkA=
 
 class-utils@^0.3.5:
@@ -2805,7 +2805,7 @@ class-utils@^0.3.5:
 
 class-validator@0.13.2:
   version "0.13.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/class-validator/-/class-validator-0.13.2.tgz#64b031e9f3f81a1e1dcd04a5d604734608b24143"
+  resolved "https://registry.npmjs.org/class-validator/-/class-validator-0.13.2.tgz#64b031e9f3f81a1e1dcd04a5d604734608b24143"
   integrity sha1-ZLAx6fP4Gh4dzQSl1gRzRgiyQUM=
   dependencies:
     libphonenumber-js "^1.9.43"
@@ -2834,7 +2834,7 @@ cliui@^5.0.0:
 
 cliui@^6.0.0:
   version "6.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/cliui/-/cliui-6.0.0.tgz"
+  resolved "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz"
   integrity sha1-UR1wLAxOQcoVbX0OlgIfI+EyJbE=
   dependencies:
     string-width "^4.2.0"
@@ -2843,7 +2843,7 @@ cliui@^6.0.0:
 
 cliui@^7.0.2:
   version "7.0.4"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/cliui/-/cliui-7.0.4.tgz"
+  resolved "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz"
   integrity sha1-oCZe5lVHb8gHrqnfPfjfd4OAi08=
   dependencies:
     string-width "^4.2.0"
@@ -2861,7 +2861,7 @@ clone-deep@^4.0.1:
 
 clone-response@^1.0.2:
   version "1.0.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/clone-response/-/clone-response-1.0.3.tgz"
+  resolved "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz"
   integrity sha1-ryAyqkeBY5nPXwodDbkC9ReruMM=
   dependencies:
     mimic-response "^1.0.0"
@@ -2891,7 +2891,7 @@ collection-visit@^1.0.0:
 
 color-convert@^1.9.0:
   version "1.9.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/color-convert/-/color-convert-1.9.3.tgz"
+  resolved "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz"
   integrity sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=
   dependencies:
     color-name "1.1.3"
@@ -2905,7 +2905,7 @@ color-convert@^2.0.1:
 
 color-name@1.1.3:
   version "1.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/color-name/-/color-name-1.1.3.tgz"
+  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
 color-name@~1.1.4:
@@ -2920,24 +2920,24 @@ colorette@^1.2.2:
 
 colorette@^2.0.14:
   version "2.0.19"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/colorette/-/colorette-2.0.19.tgz"
+  resolved "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz"
   integrity sha1-zfBE9HrUGg9LVrOg1bTm4aLVp5g=
 
 colors@1.4.0:
   version "1.4.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/colors/-/colors-1.4.0.tgz"
+  resolved "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz"
   integrity sha1-xQSRR51MG9rtLJztMs98fcI2D3g=
 
 combined-stream@^1.0.8:
   version "1.0.8"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  resolved "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=
   dependencies:
     delayed-stream "~1.0.0"
 
 commander@9.0.0:
   version "9.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/commander/-/commander-9.0.0.tgz#86d58f24ee98126568936bd1d3574e0308a99a40"
+  resolved "https://registry.npmjs.org/commander/-/commander-9.0.0.tgz#86d58f24ee98126568936bd1d3574e0308a99a40"
   integrity sha1-htWPJO6YEmVok2vR01dOAwipmkA=
 
 commander@^2.20.0, commander@^2.8.1:
@@ -2957,7 +2957,7 @@ commander@^6.1.0:
 
 commander@^7.0.0:
   version "7.2.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/commander/-/commander-7.2.0.tgz"
+  resolved "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz"
   integrity sha1-o2y1fQtQHOEI5NIFWaFQo5HZerc=
 
 commondir@^1.0.1:
@@ -2972,7 +2972,7 @@ component-emitter@^1.2.1:
 
 compress-brotli@^1.3.8:
   version "1.3.8"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/compress-brotli/-/compress-brotli-1.3.8.tgz"
+  resolved "https://registry.npmjs.org/compress-brotli/-/compress-brotli-1.3.8.tgz"
   integrity sha1-DApgyXqYkUUxTsOB6E4maC57ONs=
   dependencies:
     "@types/json-buffer" "~3.0.0"
@@ -3059,7 +3059,7 @@ crypt@0.0.2:
 
 css-loader@^6.7.1:
   version "6.7.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/css-loader/-/css-loader-6.7.1.tgz"
+  resolved "https://registry.npmjs.org/css-loader/-/css-loader-6.7.1.tgz"
   integrity sha1-6YEG8VT24brz/DvEVcuZgcHV/S4=
   dependencies:
     icss-utils "^5.1.0"
@@ -3078,17 +3078,17 @@ cssesc@^3.0.0:
 
 cssom@^0.5.0:
   version "0.5.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/cssom/-/cssom-0.5.0.tgz#d254fa92cd8b6fbd83811b9fbaed34663cc17c36"
+  resolved "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz#d254fa92cd8b6fbd83811b9fbaed34663cc17c36"
   integrity sha1-0lT6ks2Lb72DgRufuu00ZjzBfDY=
 
 cssom@~0.3.6:
   version "0.3.8"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/cssom/-/cssom-0.3.8.tgz#9f1276f5b2b463f2114d3f2c75250af8c1a36f4a"
+  resolved "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz#9f1276f5b2b463f2114d3f2c75250af8c1a36f4a"
   integrity sha1-nxJ29bK0Y/IRTT8sdSUK+MGjb0o=
 
 cssstyle@^2.3.0:
   version "2.3.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/cssstyle/-/cssstyle-2.3.0.tgz#ff665a0ddbdc31864b09647f34163443d90b0852"
+  resolved "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz#ff665a0ddbdc31864b09647f34163443d90b0852"
   integrity sha1-/2ZaDdvcMYZLCWR/NBY0Q9kLCFI=
   dependencies:
     cssom "~0.3.6"
@@ -3103,7 +3103,7 @@ d@1, d@^1.0.1:
 
 data-urls@^3.0.1:
   version "3.0.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/data-urls/-/data-urls-3.0.2.tgz#9cf24a477ae22bcef5cd5f6f0bfbc1d2d3be9143"
+  resolved "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz#9cf24a477ae22bcef5cd5f6f0bfbc1d2d3be9143"
   integrity sha1-nPJKR3riK871zV9vC/vB0tO+kUM=
   dependencies:
     abab "^2.0.6"
@@ -3117,7 +3117,7 @@ date-fns@^2.0.1:
 
 debug@4:
   version "4.3.4"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha1-Exn2V5NX8jONMzfSzdSRS7XcyGU=
   dependencies:
     ms "2.1.2"
@@ -3145,7 +3145,7 @@ debug@^4.0.1, debug@^4.1.1:
 
 debug@^4.1.0:
   version "4.3.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/debug/-/debug-4.3.2.tgz"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz"
   integrity sha1-8KScGKyHeeMdSgxgKd+3aHPHQos=
   dependencies:
     ms "2.1.2"
@@ -3157,7 +3157,7 @@ decamelize@^1.2.0:
 
 decimal.js@^10.3.1:
   version "10.3.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/decimal.js/-/decimal.js-10.3.1.tgz#d8c3a444a9c6774ba60ca6ad7261c3a94fd5e783"
+  resolved "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz#d8c3a444a9c6774ba60ca6ad7261c3a94fd5e783"
   integrity sha1-2MOkRKnGd0umDKatcmHDqU/V54M=
 
 decode-uri-component@^0.2.0:
@@ -3167,14 +3167,14 @@ decode-uri-component@^0.2.0:
 
 decompress-response@^6.0.0:
   version "6.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/decompress-response/-/decompress-response-6.0.0.tgz"
+  resolved "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz"
   integrity sha1-yjh2Et234QS9FthaqwDV7PCcZvw=
   dependencies:
     mimic-response "^3.1.0"
 
 dedent@^0.7.0:
   version "0.7.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/dedent/-/dedent-0.7.0.tgz"
+  resolved "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz"
   integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
 
 deep-eql@^3.0.1:
@@ -3196,7 +3196,7 @@ deepmerge@^4.2.2:
 
 defer-to-connect@^2.0.0:
   version "2.0.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/defer-to-connect/-/defer-to-connect-2.0.1.tgz"
+  resolved "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz"
   integrity sha1-gBa9tBQ+RjK3ejRJxiNid95SBYc=
 
 define-properties@^1.1.3:
@@ -3208,7 +3208,7 @@ define-properties@^1.1.3:
 
 define-properties@^1.1.4:
   version "1.1.4"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/define-properties/-/define-properties-1.1.4.tgz#0b14d7bd7fbeb2f3572c3a7eda80ea5d57fb05b1"
+  resolved "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz#0b14d7bd7fbeb2f3572c3a7eda80ea5d57fb05b1"
   integrity sha1-CxTXvX++svNXLDp+2oDqXVf7BbE=
   dependencies:
     has-property-descriptors "^1.0.0"
@@ -3238,7 +3238,7 @@ define-property@^2.0.2:
 
 delayed-stream@~1.0.0:
   version "1.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  resolved "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
 deprecation@^2.0.0, deprecation@^2.3.1:
@@ -3253,7 +3253,7 @@ detect-newline@^3.0.0:
 
 diff-sequences@^28.1.1:
   version "28.1.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/diff-sequences/-/diff-sequences-28.1.1.tgz"
+  resolved "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.1.1.tgz"
   integrity sha1-mYnccxJm3CkDRXpw6ZbzoEGROsY=
 
 diff@^4.0.2:
@@ -3285,7 +3285,7 @@ doctrine@^3.0.0:
 
 domexception@^4.0.0:
   version "4.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/domexception/-/domexception-4.0.0.tgz#4ad1be56ccadc86fc76d033353999a8037d03673"
+  resolved "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz#4ad1be56ccadc86fc76d033353999a8037d03673"
   integrity sha1-StG+VsytyG/HbQMzU5magDfQNnM=
   dependencies:
     webidl-conversions "^7.0.0"
@@ -3297,7 +3297,7 @@ electron-to-chromium@^1.3.723:
 
 electron-to-chromium@^1.4.188:
   version "1.4.195"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/electron-to-chromium/-/electron-to-chromium-1.4.195.tgz"
+  resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.195.tgz"
   integrity sha1-E5stlaQqPxffIXWJcjod6scdFHM=
 
 eme-encryption-scheme-polyfill@^2.0.1:
@@ -3307,7 +3307,7 @@ eme-encryption-scheme-polyfill@^2.0.1:
 
 emittery@^0.10.2:
   version "0.10.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/emittery/-/emittery-0.10.2.tgz"
+  resolved "https://registry.npmjs.org/emittery/-/emittery-0.10.2.tgz"
   integrity sha1-kC7siu24xBk4xG6ThenbfgMYKTM=
 
 emoji-regex@^7.0.1:
@@ -3334,7 +3334,7 @@ end-of-stream@^1.1.0:
 
 enhanced-resolve@^5.9.3:
   version "5.10.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz"
+  resolved "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz"
   integrity sha1-DcV5w7sqEDLjV6xFuPOm861PseY=
   dependencies:
     graceful-fs "^4.2.4"
@@ -3349,7 +3349,7 @@ enquirer@^2.3.5:
 
 envinfo@^7.7.3:
   version "7.8.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/envinfo/-/envinfo-7.8.1.tgz"
+  resolved "https://registry.npmjs.org/envinfo/-/envinfo-7.8.1.tgz"
   integrity sha1-Bjd+Pl9NN5/qesWS1a2JJ+DE1HU=
 
 error-ex@^1.3.1:
@@ -3383,7 +3383,7 @@ es-abstract@^1.18.0-next.1, es-abstract@^1.18.0-next.2:
 
 es-abstract@^1.19.0, es-abstract@^1.19.5, es-abstract@^1.20.0:
   version "1.20.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/es-abstract/-/es-abstract-1.20.1.tgz#027292cd6ef44bd12b1913b828116f54787d1814"
+  resolved "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz#027292cd6ef44bd12b1913b828116f54787d1814"
   integrity sha1-AnKSzW70S9ErGRO4KBFvVHh9GBQ=
   dependencies:
     call-bind "^1.0.2"
@@ -3412,7 +3412,7 @@ es-abstract@^1.19.0, es-abstract@^1.19.5, es-abstract@^1.20.0:
 
 es-module-lexer@^0.9.0:
   version "0.9.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/es-module-lexer/-/es-module-lexer-0.9.3.tgz"
+  resolved "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz"
   integrity sha1-bxPbAMw4QXE32vdDZvU1yOtDjxk=
 
 es-to-primitive@^1.2.1:
@@ -3456,7 +3456,7 @@ es6-map@^0.1.3:
 
 es6-object-assign@^1.1.0:
   version "1.1.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/es6-object-assign/-/es6-object-assign-1.1.0.tgz#c2c3582656247c39ea107cb1e6652b6f9f24523c"
+  resolved "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz#c2c3582656247c39ea107cb1e6652b6f9f24523c"
   integrity sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=
 
 es6-set@~0.1.5:
@@ -3503,7 +3503,7 @@ escalade@^3.1.1:
 
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+  resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
 escape-string-regexp@^2.0.0:
@@ -3518,7 +3518,7 @@ escape-string-regexp@^4.0.0:
 
 escodegen@^2.0.0:
   version "2.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/escodegen/-/escodegen-2.0.0.tgz#5e32b12833e8aa8fa35e1bf0befa89380484c7dd"
+  resolved "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz#5e32b12833e8aa8fa35e1bf0befa89380484c7dd"
   integrity sha1-XjKxKDPoqo+jXhvwvvqJOASEx90=
   dependencies:
     esprima "^4.0.1"
@@ -3618,7 +3618,7 @@ eslint-scope@5.1.1, eslint-scope@^5.1.1:
 
 eslint-scope@7.1.0:
   version "7.1.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/eslint-scope/-/eslint-scope-7.1.0.tgz#c1f6ea30ac583031f203d65c73e723b01298f153"
+  resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.0.tgz#c1f6ea30ac583031f203d65c73e723b01298f153"
   integrity sha1-wfbqMKxYMDHyA9Zcc+cjsBKY8VM=
   dependencies:
     esrecurse "^4.3.0"
@@ -3633,7 +3633,7 @@ eslint-utils@^2.1.0:
 
 eslint-visitor-keys@3.2.0:
   version "3.2.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz#6fbb166a6798ee5991358bc2daa1ba76cc1254a1"
+  resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz#6fbb166a6798ee5991358bc2daa1ba76cc1254a1"
   integrity sha1-b7sWameY7lmRNYvC2qG6dswSVKE=
 
 eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
@@ -3796,12 +3796,12 @@ eventemitter3@^4.0.3:
 
 events@^3.2.0:
   version "3.3.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/events/-/events-3.3.0.tgz"
+  resolved "https://registry.npmjs.org/events/-/events-3.3.0.tgz"
   integrity sha1-Mala0Kkk4tLEGagTrrLE6HjqdAA=
 
 execa@^5.0.0:
   version "5.1.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/execa/-/execa-5.1.1.tgz"
+  resolved "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz"
   integrity sha1-+ArZy/Qpj3vR1MlVXCHpN0HEEd0=
   dependencies:
     cross-spawn "^7.0.3"
@@ -3839,7 +3839,7 @@ expand-brackets@^2.1.4:
 
 expect@^28.1.3:
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/expect/-/expect-28.1.3.tgz"
+  resolved "https://registry.npmjs.org/expect/-/expect-28.1.3.tgz"
   integrity sha1-kKfBoSTxgkEz3UUzzOLSvctmA+w=
   dependencies:
     "@jest/expect-utils" "^28.1.3"
@@ -3901,7 +3901,7 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
 
 fastest-levenshtein@^1.0.12:
   version "1.0.14"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/fastest-levenshtein/-/fastest-levenshtein-1.0.14.tgz"
+  resolved "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.14.tgz"
   integrity sha1-kFQ4Tkt6eMiNAaRDLcGIca8KyFk=
 
 fb-watchman@^2.0.0:
@@ -4021,7 +4021,7 @@ flow-bin@^0.114.0:
 
 flow-typed@^3.8.0:
   version "3.8.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/flow-typed/-/flow-typed-3.8.0.tgz"
+  resolved "https://registry.npmjs.org/flow-typed/-/flow-typed-3.8.0.tgz"
   integrity sha1-Ltg+RyPt5IpscRNd6QKJxAMaGcY=
   dependencies:
     "@octokit/rest" "^18.12.0"
@@ -4042,7 +4042,7 @@ flow-typed@^3.8.0:
 
 flowgen@^1.10.0:
   version "1.20.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/flowgen/-/flowgen-1.20.0.tgz"
+  resolved "https://registry.npmjs.org/flowgen/-/flowgen-1.20.0.tgz"
   integrity sha1-JotJUGQpxdp2XaXNSf8jH6ZGX+c=
   dependencies:
     "@babel/code-frame" "^7.16.7"
@@ -4056,7 +4056,7 @@ flowgen@^1.10.0:
 
 for-each@^0.3.3:
   version "0.3.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
+  resolved "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
   integrity sha1-abRH6IoKXTLD5whPPxcQA0shN24=
   dependencies:
     is-callable "^1.1.3"
@@ -4068,7 +4068,7 @@ for-in@^1.0.2:
 
 form-data@^4.0.0:
   version "4.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  resolved "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
   integrity sha1-k5Gdrq82HuUpWEubMWZNwSyfpFI=
   dependencies:
     asynckit "^0.4.0"
@@ -4100,7 +4100,7 @@ fs-extra@^3.0.1:
 
 fs-extra@^8.1.0:
   version "8.1.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/fs-extra/-/fs-extra-8.1.0.tgz"
+  resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz"
   integrity sha1-SdQ8RaiM2Wd2aMt74bRu/bjS4cA=
   dependencies:
     graceful-fs "^4.2.0"
@@ -4119,17 +4119,17 @@ fs.realpath@^1.0.0:
 
 fsevents@^2.3.2, fsevents@~2.3.1, fsevents@~2.3.2:
   version "2.3.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha1-ilJveLj99GI7cJ4Ll1xSwkwC/Ro=
 
 function-bind@^1.1.1:
   version "1.1.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/function-bind/-/function-bind-1.1.1.tgz"
+  resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz"
   integrity sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=
 
 function.prototype.name@^1.1.5:
   version "1.1.5"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/function.prototype.name/-/function.prototype.name-1.1.5.tgz#cce0505fe1ffb80503e6f9e46cc64e46a12a9621"
+  resolved "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz#cce0505fe1ffb80503e6f9e46cc64e46a12a9621"
   integrity sha1-zOBQX+H/uAUD5vnkbMZORqEqliE=
   dependencies:
     call-bind "^1.0.2"
@@ -4144,7 +4144,7 @@ functional-red-black-tree@^1.0.1:
 
 functions-have-names@^1.2.2:
   version "1.2.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
+  resolved "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha1-BAT+TuK6L2B/Dg7DyAuumUEzuDQ=
 
 generate-function@^2.0.0:
@@ -4187,7 +4187,7 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.1:
 
 get-intrinsic@^1.1.0:
   version "1.1.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/get-intrinsic/-/get-intrinsic-1.1.2.tgz#336975123e05ad0b7ba41f152ee4aadbea6cf598"
+  resolved "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz#336975123e05ad0b7ba41f152ee4aadbea6cf598"
   integrity sha1-M2l1Ej4FrQt7pB8VLuSq2+ps9Zg=
   dependencies:
     function-bind "^1.1.1"
@@ -4201,19 +4201,19 @@ get-package-type@^0.1.0:
 
 get-stream@^5.1.0:
   version "5.2.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/get-stream/-/get-stream-5.2.0.tgz"
+  resolved "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz"
   integrity sha1-SWaheV7lrOZecGxLe+txJX1uItM=
   dependencies:
     pump "^3.0.0"
 
 get-stream@^6.0.0:
   version "6.0.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/get-stream/-/get-stream-6.0.1.tgz"
+  resolved "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz"
   integrity sha1-omLY7vZ6ztV8KFKtYWdSakPL97c=
 
 get-symbol-description@^1.0.0:
   version "1.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/get-symbol-description/-/get-symbol-description-1.0.0.tgz#7fdb81c900101fbd564dd5f1a30af5aadc1e58d6"
+  resolved "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz#7fdb81c900101fbd564dd5f1a30af5aadc1e58d6"
   integrity sha1-f9uByQAQH71WTdXxowr1qtweWNY=
   dependencies:
     call-bind "^1.0.2"
@@ -4241,7 +4241,7 @@ glob-parent@^5.0.0, glob-parent@~5.1.0, glob-parent@~5.1.2:
 
 glob-to-regexp@^0.4.1:
   version "0.4.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz"
+  resolved "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz"
   integrity sha1-x1KXCHyFG5pXi9IX3VmpL1n+VG4=
 
 glob@^7.0.0, glob@^7.0.3, glob@^7.1.3, glob@^7.1.4, glob@~7.1.1:
@@ -4258,7 +4258,7 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.1.3, glob@^7.1.4, glob@~7.1.1:
 
 glob@^7.1.6:
   version "7.2.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/glob/-/glob-7.2.3.tgz"
+  resolved "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz"
   integrity sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=
   dependencies:
     fs.realpath "^1.0.0"
@@ -4270,7 +4270,7 @@ glob@^7.1.6:
 
 globals@^11.1.0:
   version "11.12.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/globals/-/globals-11.12.0.tgz"
+  resolved "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz"
   integrity sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4=
 
 globals@^12.1.0:
@@ -4310,7 +4310,7 @@ gonzales-pe-sl@^4.2.3:
 
 got@^11.8.5:
   version "11.8.5"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/got/-/got-11.8.5.tgz"
+  resolved "https://registry.npmjs.org/got/-/got-11.8.5.tgz"
   integrity sha1-znfQRRNt5W6PAkvruC6jSbxzAEY=
   dependencies:
     "@sindresorhus/is" "^4.0.0"
@@ -4332,7 +4332,7 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
 
 graceful-fs@^4.2.0, graceful-fs@^4.2.4, graceful-fs@^4.2.9:
   version "4.2.10"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/graceful-fs/-/graceful-fs-4.2.10.tgz"
+  resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz"
   integrity sha1-FH06AG2kyjzhRyjHrvwofDZ9emw=
 
 has-ansi@^2.0.0:
@@ -4349,12 +4349,12 @@ has-bigints@^1.0.1:
 
 has-bigints@^1.0.2:
   version "1.0.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
+  resolved "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
   integrity sha1-CHG9Pj1RYm9soJZmaLo11WAtbqo=
 
 has-flag@^3.0.0:
   version "3.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/has-flag/-/has-flag-3.0.0.tgz"
+  resolved "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
 
 has-flag@^4.0.0:
@@ -4364,7 +4364,7 @@ has-flag@^4.0.0:
 
 has-property-descriptors@^1.0.0:
   version "1.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz#610708600606d36961ed04c196193b6a607fa861"
+  resolved "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz#610708600606d36961ed04c196193b6a607fa861"
   integrity sha1-YQcIYAYG02lh7QTBlhk7amB/qGE=
   dependencies:
     get-intrinsic "^1.1.1"
@@ -4376,12 +4376,12 @@ has-symbols@^1.0.1, has-symbols@^1.0.2:
 
 has-symbols@^1.0.3:
   version "1.0.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
+  resolved "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
   integrity sha1-u3ssQ0klHc6HsSX3vfh0qnyLOfg=
 
 has-tostringtag@^1.0.0:
   version "1.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/has-tostringtag/-/has-tostringtag-1.0.0.tgz#7e133818a7d394734f941e73c3d3f9291e658b25"
+  resolved "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz#7e133818a7d394734f941e73c3d3f9291e658b25"
   integrity sha1-fhM4GKfTlHNPlB5zw9P5KR5liyU=
   dependencies:
     has-symbols "^1.0.2"
@@ -4419,7 +4419,7 @@ has-values@^1.0.0:
 
 has@^1.0.3:
   version "1.0.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/has/-/has-1.0.3.tgz"
+  resolved "https://registry.npmjs.org/has/-/has-1.0.3.tgz"
   integrity sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=
   dependencies:
     function-bind "^1.1.1"
@@ -4446,7 +4446,7 @@ hosted-git-info@^2.1.4:
 
 html-encoding-sniffer@^3.0.0:
   version "3.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz#2cb1a8cf0db52414776e5b2a7a04d5dd98158de9"
+  resolved "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz#2cb1a8cf0db52414776e5b2a7a04d5dd98158de9"
   integrity sha1-LLGozw21JBR3blsqegTV3ZgVjek=
   dependencies:
     whatwg-encoding "^2.0.0"
@@ -4458,12 +4458,12 @@ html-escaper@^2.0.0:
 
 http-cache-semantics@^4.0.0:
   version "4.1.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz"
+  resolved "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz"
   integrity sha1-SekcXL82yblLz81xwj1SSex045A=
 
 http-proxy-agent@^5.0.0:
   version "5.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz#5129800203520d434f142bc78ff3c170800f2b43"
+  resolved "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz#5129800203520d434f142bc78ff3c170800f2b43"
   integrity sha1-USmAAgNSDUNPFCvHj/PBcIAPK0M=
   dependencies:
     "@tootallnate/once" "2"
@@ -4472,7 +4472,7 @@ http-proxy-agent@^5.0.0:
 
 http2-wrapper@^1.0.0-beta.5.2:
   version "1.0.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/http2-wrapper/-/http2-wrapper-1.0.3.tgz"
+  resolved "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz"
   integrity sha1-uPVeDB8l1OvQizsMLAeflZCACz0=
   dependencies:
     quick-lru "^5.1.1"
@@ -4480,7 +4480,7 @@ http2-wrapper@^1.0.0-beta.5.2:
 
 https-proxy-agent@^5.0.0:
   version "5.0.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  resolved "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
   integrity sha1-xZ7yJKBP6LdU89sAY6Jeow0ABdY=
   dependencies:
     agent-base "6"
@@ -4488,7 +4488,7 @@ https-proxy-agent@^5.0.0:
 
 human-signals@^2.1.0:
   version "2.1.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/human-signals/-/human-signals-2.1.0.tgz"
+  resolved "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz"
   integrity sha1-3JH8ukLk0G5Kuu0zs+ejwC9RTqA=
 
 iconv-lite@0.6.3, iconv-lite@^0.6.2:
@@ -4515,7 +4515,7 @@ ignore@^4.0.6:
 
 immutable@^4.0.0:
   version "4.1.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/immutable/-/immutable-4.1.0.tgz#f795787f0db780183307b9eb2091fcac1f6fafef"
+  resolved "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz#f795787f0db780183307b9eb2091fcac1f6fafef"
   integrity sha1-95V4fw23gBgzB7nrIJH8rB9vr+8=
 
 import-fresh@^3.0.0, import-fresh@^3.2.1:
@@ -4578,7 +4578,7 @@ inquirer@^0.12.0:
 
 internal-slot@^1.0.3:
   version "1.0.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/internal-slot/-/internal-slot-1.0.3.tgz#7347e307deeea2faac2ac6205d4bc7d34967f59c"
+  resolved "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz#7347e307deeea2faac2ac6205d4bc7d34967f59c"
   integrity sha1-c0fjB97uovqsKsYgXUvH00ln9Zw=
   dependencies:
     get-intrinsic "^1.1.0"
@@ -4592,12 +4592,12 @@ interpret@^1.0.0:
 
 interpret@^2.2.0:
   version "2.2.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/interpret/-/interpret-2.2.0.tgz"
+  resolved "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz"
   integrity sha1-GnigtZZcQKVBbQB61vUK0nxBffk=
 
 inversify@6.0.1:
   version "6.0.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/inversify/-/inversify-6.0.1.tgz#b20d35425d5d8c5cd156120237aad0008d969f02"
+  resolved "https://registry.npmjs.org/inversify/-/inversify-6.0.1.tgz#b20d35425d5d8c5cd156120237aad0008d969f02"
   integrity sha1-sg01Ql1djFzRVhICN6rQAI2WnwI=
 
 is-accessor-descriptor@^0.1.6:
@@ -4616,7 +4616,7 @@ is-accessor-descriptor@^1.0.0:
 
 is-arguments@^1.0.4:
   version "1.1.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/is-arguments/-/is-arguments-1.1.1.tgz#15b3f88fda01f2a97fec84ca761a560f123efa9b"
+  resolved "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz#15b3f88fda01f2a97fec84ca761a560f123efa9b"
   integrity sha1-FbP4j9oB8ql/7ITKdhpWDxI++ps=
   dependencies:
     call-bind "^1.0.2"
@@ -4660,7 +4660,7 @@ is-buffer@^1.1.5, is-buffer@~1.1.6:
 
 is-callable@^1.1.3, is-callable@^1.2.4:
   version "1.2.4"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/is-callable/-/is-callable-1.2.4.tgz#47301d58dd0259407865547853df6d61fe471945"
+  resolved "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz#47301d58dd0259407865547853df6d61fe471945"
   integrity sha1-RzAdWN0CWUB4ZVR4U99tYf5HGUU=
 
 is-callable@^1.1.4, is-callable@^1.2.3:
@@ -4670,7 +4670,7 @@ is-callable@^1.1.4, is-callable@^1.2.3:
 
 is-core-module@^2.2.0:
   version "2.6.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/is-core-module/-/is-core-module-2.6.0.tgz"
+  resolved "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz"
   integrity sha1-11U7JSb+Wbkro+QMjfdX7Ipwnhk=
   dependencies:
     has "^1.0.3"
@@ -4684,7 +4684,7 @@ is-core-module@^2.4.0:
 
 is-core-module@^2.9.0:
   version "2.9.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/is-core-module/-/is-core-module-2.9.0.tgz"
+  resolved "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz"
   integrity sha1-4cNEKc1Rxt2eCeB5njluJ7GanGk=
   dependencies:
     has "^1.0.3"
@@ -4767,7 +4767,7 @@ is-generator-fn@^2.0.0:
 
 is-generator-function@^1.0.7:
   version "1.0.10"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/is-generator-function/-/is-generator-function-1.0.10.tgz#f1558baf1ac17e0deea7c0415c438351ff2b3c72"
+  resolved "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz#f1558baf1ac17e0deea7c0415c438351ff2b3c72"
   integrity sha1-8VWLrxrBfg3up8BBXEODUf8rPHI=
   dependencies:
     has-tostringtag "^1.0.0"
@@ -4804,7 +4804,7 @@ is-my-json-valid@^2.10.0:
 
 is-nan@^1.2.1:
   version "1.3.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/is-nan/-/is-nan-1.3.2.tgz#043a54adea31748b55b6cd4e09aadafa69bd9e1d"
+  resolved "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz#043a54adea31748b55b6cd4e09aadafa69bd9e1d"
   integrity sha1-BDpUreoxdItVts1OCara+mm9nh0=
   dependencies:
     call-bind "^1.0.0"
@@ -4817,7 +4817,7 @@ is-negative-zero@^2.0.1:
 
 is-negative-zero@^2.0.2:
   version "2.0.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/is-negative-zero/-/is-negative-zero-2.0.2.tgz#7bf6f03a28003b8b3965de3ac26f664d765f3150"
+  resolved "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz#7bf6f03a28003b8b3965de3ac26f664d765f3150"
   integrity sha1-e/bwOigAO4s5Zd46wm9mTXZfMVA=
 
 is-number-object@^1.0.4:
@@ -4846,12 +4846,12 @@ is-plain-object@^2.0.3, is-plain-object@^2.0.4:
 
 is-plain-object@^5.0.0:
   version "5.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/is-plain-object/-/is-plain-object-5.0.0.tgz"
+  resolved "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz"
   integrity sha1-RCf1CrNCnpAl6n1S6QQ6nvQVk0Q=
 
 is-potential-custom-element-name@^1.0.1:
   version "1.0.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
+  resolved "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
   integrity sha1-Fx7W8Z46xVQ5Tt94yqBXhKRb67U=
 
 is-property@^1.0.0, is-property@^1.0.2:
@@ -4869,7 +4869,7 @@ is-regex@^1.1.2:
 
 is-regex@^1.1.4:
   version "1.1.4"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/is-regex/-/is-regex-1.1.4.tgz#eef5663cd59fa4c0ae339505323df6854bb15958"
+  resolved "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz#eef5663cd59fa4c0ae339505323df6854bb15958"
   integrity sha1-7vVmPNWfpMCuM5UFMj32hUuxWVg=
   dependencies:
     call-bind "^1.0.2"
@@ -4882,7 +4882,7 @@ is-resolvable@^1.0.0:
 
 is-shared-array-buffer@^1.0.2:
   version "1.0.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz#8f259c573b60b6a32d4058a1a07430c0a7344c79"
+  resolved "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz#8f259c573b60b6a32d4058a1a07430c0a7344c79"
   integrity sha1-jyWcVztgtqMtQFihoHQwwKc0THk=
   dependencies:
     call-bind "^1.0.2"
@@ -4899,7 +4899,7 @@ is-string@^1.0.5:
 
 is-string@^1.0.7:
   version "1.0.7"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/is-string/-/is-string-1.0.7.tgz#0dd12bf2006f255bb58f695110eff7491eebc0fd"
+  resolved "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz#0dd12bf2006f255bb58f695110eff7491eebc0fd"
   integrity sha1-DdEr8gBvJVu1j2lREO/3SR7rwP0=
   dependencies:
     has-tostringtag "^1.0.0"
@@ -4913,7 +4913,7 @@ is-symbol@^1.0.2, is-symbol@^1.0.3:
 
 is-typed-array@^1.1.3, is-typed-array@^1.1.9:
   version "1.1.9"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/is-typed-array/-/is-typed-array-1.1.9.tgz#246d77d2871e7d9f5aeb1d54b9f52c71329ece67"
+  resolved "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.9.tgz#246d77d2871e7d9f5aeb1d54b9f52c71329ece67"
   integrity sha1-JG130ocefZ9a6x1UufUscTKezmc=
   dependencies:
     available-typed-arrays "^1.0.5"
@@ -4924,7 +4924,7 @@ is-typed-array@^1.1.3, is-typed-array@^1.1.9:
 
 is-weakref@^1.0.2:
   version "1.0.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/is-weakref/-/is-weakref-1.0.2.tgz#9529f383a9338205e89765e0392efc2f100f06f2"
+  resolved "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz#9529f383a9338205e89765e0392efc2f100f06f2"
   integrity sha1-lSnzg6kzggXol2XgOS78LxAPBvI=
   dependencies:
     call-bind "^1.0.2"
@@ -4968,12 +4968,12 @@ istanbul-lib-coverage@^3.0.0:
 
 istanbul-lib-coverage@^3.2.0:
   version "3.2.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz"
+  resolved "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz"
   integrity sha1-GJ55CdCjn6Wj361bA/cZR3cBkdM=
 
 istanbul-lib-instrument@^5.0.4, istanbul-lib-instrument@^5.1.0:
   version "5.2.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.0.tgz"
+  resolved "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.0.tgz"
   integrity sha1-MdGL3RJ/gl3QLqe/39kG+KuEDp8=
   dependencies:
     "@babel/core" "^7.12.3"
@@ -5002,7 +5002,7 @@ istanbul-lib-source-maps@^4.0.0:
 
 istanbul-reports@^3.1.3:
   version "3.1.5"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/istanbul-reports/-/istanbul-reports-3.1.5.tgz"
+  resolved "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.5.tgz"
   integrity sha1-zJpqslyyVlmBDkeF7Z2ft0JXi64=
   dependencies:
     html-escaper "^2.0.0"
@@ -5015,7 +5015,7 @@ javascript-natural-sort@^0.7.1:
 
 javascript-obfuscator@^4.0.0:
   version "4.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/javascript-obfuscator/-/javascript-obfuscator-4.0.0.tgz#9c1dd209f8b1ef4e49b7a0f20b95bffa6a6b2e79"
+  resolved "https://registry.npmjs.org/javascript-obfuscator/-/javascript-obfuscator-4.0.0.tgz#9c1dd209f8b1ef4e49b7a0f20b95bffa6a6b2e79"
   integrity sha1-nB3SCfix705Jt6DyC5W/+mprLnk=
   dependencies:
     "@javascript-obfuscator/escodegen" "2.3.0"
@@ -5044,7 +5044,7 @@ javascript-obfuscator@^4.0.0:
 
 jest-changed-files@^28.1.3:
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/jest-changed-files/-/jest-changed-files-28.1.3.tgz"
+  resolved "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-28.1.3.tgz"
   integrity sha1-2a7uZ5K+NobEfLmIqOr4L/QjiDE=
   dependencies:
     execa "^5.0.0"
@@ -5052,7 +5052,7 @@ jest-changed-files@^28.1.3:
 
 jest-circus@^28.1.3:
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/jest-circus/-/jest-circus-28.1.3.tgz"
+  resolved "https://registry.npmjs.org/jest-circus/-/jest-circus-28.1.3.tgz"
   integrity sha1-0UvRHPjuGgPWmQLcR7a9RjTuAOQ=
   dependencies:
     "@jest/environment" "^28.1.3"
@@ -5077,7 +5077,7 @@ jest-circus@^28.1.3:
 
 jest-cli@^28.1.3:
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/jest-cli/-/jest-cli-28.1.3.tgz"
+  resolved "https://registry.npmjs.org/jest-cli/-/jest-cli-28.1.3.tgz"
   integrity sha1-VYszxXfQbeVQh7hEjTc7n2VORrI=
   dependencies:
     "@jest/core" "^28.1.3"
@@ -5095,7 +5095,7 @@ jest-cli@^28.1.3:
 
 jest-config@^28.1.3:
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/jest-config/-/jest-config-28.1.3.tgz"
+  resolved "https://registry.npmjs.org/jest-config/-/jest-config-28.1.3.tgz"
   integrity sha1-4xXh9z3zysMUR+7YuHQKR3OS7GA=
   dependencies:
     "@babel/core" "^7.11.6"
@@ -5123,7 +5123,7 @@ jest-config@^28.1.3:
 
 jest-diff@^28.1.3:
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/jest-diff/-/jest-diff-28.1.3.tgz"
+  resolved "https://registry.npmjs.org/jest-diff/-/jest-diff-28.1.3.tgz"
   integrity sha1-lIoZLYb056ZMUmStTaSHcTPYeS8=
   dependencies:
     chalk "^4.0.0"
@@ -5133,14 +5133,14 @@ jest-diff@^28.1.3:
 
 jest-docblock@^28.1.1:
   version "28.1.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/jest-docblock/-/jest-docblock-28.1.1.tgz"
+  resolved "https://registry.npmjs.org/jest-docblock/-/jest-docblock-28.1.1.tgz"
   integrity sha1-b1FcO/hBUW2C7NV6Yu7ZIEwvQqg=
   dependencies:
     detect-newline "^3.0.0"
 
 jest-each@^28.1.3:
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/jest-each/-/jest-each-28.1.3.tgz"
+  resolved "https://registry.npmjs.org/jest-each/-/jest-each-28.1.3.tgz"
   integrity sha1-vdFRbtvisfNWnP2tms1UMEACj4E=
   dependencies:
     "@jest/types" "^28.1.3"
@@ -5151,7 +5151,7 @@ jest-each@^28.1.3:
 
 jest-environment-jsdom@^28.1.3:
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/jest-environment-jsdom/-/jest-environment-jsdom-28.1.3.tgz#2d4e5d61b7f1d94c3bddfbb21f0308ee506c09fb"
+  resolved "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-28.1.3.tgz#2d4e5d61b7f1d94c3bddfbb21f0308ee506c09fb"
   integrity sha1-LU5dYbfx2Uw73fuyHwMI7lBsCfs=
   dependencies:
     "@jest/environment" "^28.1.3"
@@ -5165,7 +5165,7 @@ jest-environment-jsdom@^28.1.3:
 
 jest-environment-node@^28.1.3:
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/jest-environment-node/-/jest-environment-node-28.1.3.tgz"
+  resolved "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-28.1.3.tgz"
   integrity sha1-fnT+QOtkW51WwMS3DKQ1f6o0m+U=
   dependencies:
     "@jest/environment" "^28.1.3"
@@ -5177,12 +5177,12 @@ jest-environment-node@^28.1.3:
 
 jest-get-type@^28.0.2:
   version "28.0.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/jest-get-type/-/jest-get-type-28.0.2.tgz"
+  resolved "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz"
   integrity sha1-NGIuYo5P3NeT1G24okIieQH88gM=
 
 jest-haste-map@^28.1.3:
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/jest-haste-map/-/jest-haste-map-28.1.3.tgz"
+  resolved "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-28.1.3.tgz"
   integrity sha1-q9VFESmjjZhBBJZE80sDQwiUTis=
   dependencies:
     "@jest/types" "^28.1.3"
@@ -5201,7 +5201,7 @@ jest-haste-map@^28.1.3:
 
 jest-leak-detector@^28.1.3:
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/jest-leak-detector/-/jest-leak-detector-28.1.3.tgz"
+  resolved "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-28.1.3.tgz"
   integrity sha1-pmhdmwdL6Z463ugWzoT9MHleZU0=
   dependencies:
     jest-get-type "^28.0.2"
@@ -5209,7 +5209,7 @@ jest-leak-detector@^28.1.3:
 
 jest-matcher-utils@^28.1.3:
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/jest-matcher-utils/-/jest-matcher-utils-28.1.3.tgz"
+  resolved "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-28.1.3.tgz"
   integrity sha1-WnfxwSndW6O01/wgcogGx4iTFG4=
   dependencies:
     chalk "^4.0.0"
@@ -5219,7 +5219,7 @@ jest-matcher-utils@^28.1.3:
 
 jest-message-util@^28.1.3:
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/jest-message-util/-/jest-message-util-28.1.3.tgz"
+  resolved "https://registry.npmjs.org/jest-message-util/-/jest-message-util-28.1.3.tgz"
   integrity sha1-Iy3vfy4zPx7syQZJtblLAFXnxD0=
   dependencies:
     "@babel/code-frame" "^7.12.13"
@@ -5234,7 +5234,7 @@ jest-message-util@^28.1.3:
 
 jest-mock@^28.1.3:
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/jest-mock/-/jest-mock-28.1.3.tgz"
+  resolved "https://registry.npmjs.org/jest-mock/-/jest-mock-28.1.3.tgz"
   integrity sha1-1Omx/IOL6llcd6tzZy6/UTqySdo=
   dependencies:
     "@jest/types" "^28.1.3"
@@ -5247,12 +5247,12 @@ jest-pnp-resolver@^1.2.2:
 
 jest-regex-util@^28.0.2:
   version "28.0.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/jest-regex-util/-/jest-regex-util-28.0.2.tgz"
+  resolved "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-28.0.2.tgz"
   integrity sha1-r9w3ejsl+26Aglrc92yFTlv0fq0=
 
 jest-resolve-dependencies@^28.1.3:
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/jest-resolve-dependencies/-/jest-resolve-dependencies-28.1.3.tgz"
+  resolved "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-28.1.3.tgz"
   integrity sha1-jGXXWDRg33J1xuonkZAfqXXB/mY=
   dependencies:
     jest-regex-util "^28.0.2"
@@ -5260,7 +5260,7 @@ jest-resolve-dependencies@^28.1.3:
 
 jest-resolve@^28.1.3:
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/jest-resolve/-/jest-resolve-28.1.3.tgz"
+  resolved "https://registry.npmjs.org/jest-resolve/-/jest-resolve-28.1.3.tgz"
   integrity sha1-z7NhADQd27Bh7HgUJrPDHrUaoKg=
   dependencies:
     chalk "^4.0.0"
@@ -5275,7 +5275,7 @@ jest-resolve@^28.1.3:
 
 jest-runner@^28.1.3:
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/jest-runner/-/jest-runner-28.1.3.tgz"
+  resolved "https://registry.npmjs.org/jest-runner/-/jest-runner-28.1.3.tgz"
   integrity sha1-Xu4l/r1zC0cTos39dr3VVXhA+aE=
   dependencies:
     "@jest/console" "^28.1.3"
@@ -5302,7 +5302,7 @@ jest-runner@^28.1.3:
 
 jest-runtime@^28.1.3:
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/jest-runtime/-/jest-runtime-28.1.3.tgz"
+  resolved "https://registry.npmjs.org/jest-runtime/-/jest-runtime-28.1.3.tgz"
   integrity sha1-pXZDRYI1qlPo7HghlJ5yiWDQYF8=
   dependencies:
     "@jest/environment" "^28.1.3"
@@ -5330,7 +5330,7 @@ jest-runtime@^28.1.3:
 
 jest-snapshot@^28.1.3:
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/jest-snapshot/-/jest-snapshot-28.1.3.tgz"
+  resolved "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-28.1.3.tgz"
   integrity sha1-F0Z7OrjduB4vYF2wVYPWk4j8Bmg=
   dependencies:
     "@babel/core" "^7.11.6"
@@ -5359,7 +5359,7 @@ jest-snapshot@^28.1.3:
 
 jest-util@^28.1.3:
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/jest-util/-/jest-util-28.1.3.tgz"
+  resolved "https://registry.npmjs.org/jest-util/-/jest-util-28.1.3.tgz"
   integrity sha1-9PkyqgB08GeZQyIP+cu6fklwKLA=
   dependencies:
     "@jest/types" "^28.1.3"
@@ -5371,7 +5371,7 @@ jest-util@^28.1.3:
 
 jest-validate@^28.1.3:
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/jest-validate/-/jest-validate-28.1.3.tgz"
+  resolved "https://registry.npmjs.org/jest-validate/-/jest-validate-28.1.3.tgz"
   integrity sha1-4yImf9XnxkzqRilhLDV7valiKd8=
   dependencies:
     "@jest/types" "^28.1.3"
@@ -5383,7 +5383,7 @@ jest-validate@^28.1.3:
 
 jest-watcher@^28.1.3:
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/jest-watcher/-/jest-watcher-28.1.3.tgz"
+  resolved "https://registry.npmjs.org/jest-watcher/-/jest-watcher-28.1.3.tgz"
   integrity sha1-xgI6WboiVeO0xXF5/JQWSz5zq9Q=
   dependencies:
     "@jest/test-result" "^28.1.3"
@@ -5397,7 +5397,7 @@ jest-watcher@^28.1.3:
 
 jest-worker@^27.4.5:
   version "27.5.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/jest-worker/-/jest-worker-27.5.1.tgz"
+  resolved "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz"
   integrity sha1-jRRvCQDolzsQa29zzB6ajLhvjbA=
   dependencies:
     "@types/node" "*"
@@ -5406,7 +5406,7 @@ jest-worker@^27.4.5:
 
 jest-worker@^28.1.3:
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/jest-worker/-/jest-worker-28.1.3.tgz"
+  resolved "https://registry.npmjs.org/jest-worker/-/jest-worker-28.1.3.tgz"
   integrity sha1-fjxM4/oj0btqzLFp5/OW+Y7Uu5g=
   dependencies:
     "@types/node" "*"
@@ -5415,17 +5415,17 @@ jest-worker@^28.1.3:
 
 jmespath@^0.16.0:
   version "0.16.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/jmespath/-/jmespath-0.16.0.tgz"
+  resolved "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz"
   integrity sha1-sVsKhd/U2TDUPmntYFlDyAJ4UHY=
 
 js-string-escape@1.0.1:
   version "1.0.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/js-string-escape/-/js-string-escape-1.0.1.tgz#e2625badbc0d67c7533e9edc1068c587ae4137ef"
+  resolved "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz#e2625badbc0d67c7533e9edc1068c587ae4137ef"
   integrity sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8=
 
 js-tokens@^4.0.0:
   version "4.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/js-tokens/-/js-tokens-4.0.0.tgz"
+  resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
   integrity sha1-GSA/tZmR35jjoocFDUZHzerzJJk=
 
 js-yaml@^3.13.1, js-yaml@^3.4.6, js-yaml@^3.5.1, js-yaml@^3.5.4:
@@ -5438,7 +5438,7 @@ js-yaml@^3.13.1, js-yaml@^3.4.6, js-yaml@^3.5.1, js-yaml@^3.5.4:
 
 jsdom@^19.0.0:
   version "19.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/jsdom/-/jsdom-19.0.0.tgz#93e67c149fe26816d38a849ea30ac93677e16b6a"
+  resolved "https://registry.npmjs.org/jsdom/-/jsdom-19.0.0.tgz#93e67c149fe26816d38a849ea30ac93677e16b6a"
   integrity sha1-k+Z8FJ/iaBbTioSeowrJNnfha2o=
   dependencies:
     abab "^2.0.5"
@@ -5471,7 +5471,7 @@ jsdom@^19.0.0:
 
 jsesc@^2.5.1:
   version "2.5.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/jsesc/-/jsesc-2.5.2.tgz"
+  resolved "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz"
   integrity sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q=
 
 jsesc@~0.5.0:
@@ -5481,7 +5481,7 @@ jsesc@~0.5.0:
 
 json-buffer@3.0.1, json-buffer@~3.0.1:
   version "3.0.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/json-buffer/-/json-buffer-3.0.1.tgz"
+  resolved "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz"
   integrity sha1-kziAKjDTtmBfvgYT4JQAjKjAWhM=
 
 json-logic-js@^2.0.0:
@@ -5496,7 +5496,7 @@ json-parse-better-errors@^1.0.1:
 
 json-parse-even-better-errors@^2.3.0, json-parse-even-better-errors@^2.3.1:
   version "2.3.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz"
+  resolved "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz"
   integrity sha1-fEeAWpQxmSjgV3dAXcEuH3pO4C0=
 
 json-schema-traverse@^0.4.1:
@@ -5542,12 +5542,12 @@ json5@^2.1.2:
 
 json5@^2.2.1:
   version "2.2.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/json5/-/json5-2.2.1.tgz"
+  resolved "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz"
   integrity sha1-ZV1Q7R5vla0aPKq6vSsO/aELOVw=
 
 jsoneditor@^9.9.0:
   version "9.9.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/jsoneditor/-/jsoneditor-9.9.0.tgz"
+  resolved "https://registry.npmjs.org/jsoneditor/-/jsoneditor-9.9.0.tgz"
   integrity sha1-Zx4SMeI8Q+vG4etD/pey+XsVb68=
   dependencies:
     ace-builds "^1.6.0"
@@ -5586,7 +5586,7 @@ jsonpointer@^4.0.0:
 
 jsonrepair@^2.2.1:
   version "2.2.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/jsonrepair/-/jsonrepair-2.2.1.tgz"
+  resolved "https://registry.npmjs.org/jsonrepair/-/jsonrepair-2.2.1.tgz"
   integrity sha1-fGJXw2VQoxAVDEGrfV1Mq3GChFY=
 
 jsonschema@^1.4.0:
@@ -5601,7 +5601,7 @@ just-extend@^4.0.2:
 
 keyv@^4.0.0:
   version "4.3.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/keyv/-/keyv-4.3.3.tgz"
+  resolved "https://registry.npmjs.org/keyv/-/keyv-4.3.3.tgz"
   integrity sha1-bBvNpjU6npb8G04a64A6bjUJC6k=
   dependencies:
     compress-brotli "^1.3.8"
@@ -5664,12 +5664,12 @@ levn@^0.4.1:
 
 libphonenumber-js@^1.9.43:
   version "1.10.9"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/libphonenumber-js/-/libphonenumber-js-1.10.9.tgz#e9dd7e3fd57aea694b5116d9a8d94dc2f2e5b15c"
+  resolved "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.9.tgz#e9dd7e3fd57aea694b5116d9a8d94dc2f2e5b15c"
   integrity sha1-6d1+P9V66mlLURbZqNlNwvLlsVw=
 
 lines-and-columns@^1.1.6:
   version "1.2.4"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/lines-and-columns/-/lines-and-columns-1.2.4.tgz"
+  resolved "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz"
   integrity sha1-7KKE910pZQeTCdwK2SVauy68FjI=
 
 load-json-file@^4.0.0:
@@ -5684,7 +5684,7 @@ load-json-file@^4.0.0:
 
 loader-runner@^4.2.0:
   version "4.3.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/loader-runner/-/loader-runner-4.3.0.tgz"
+  resolved "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz"
   integrity sha1-wbShY7mfYUgwNTsWdV5xSawjFOE=
 
 loader-utils@^1.2.3, loader-utils@^1.4.0:
@@ -5777,7 +5777,7 @@ lolex@^5.0.1, lolex@^5.1.2:
 
 lowercase-keys@^2.0.0:
   version "2.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/lowercase-keys/-/lowercase-keys-2.0.0.tgz"
+  resolved "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz"
   integrity sha1-JgPni3tLAAbLyi+8yKMgJVislHk=
 
 lru-cache@^6.0.0:
@@ -5804,7 +5804,7 @@ make-dir@^3.0.0, make-dir@^3.0.2, make-dir@^3.1.0:
 
 makeerror@1.0.12:
   version "1.0.12"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/makeerror/-/makeerror-1.0.12.tgz"
+  resolved "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz"
   integrity sha1-Pl3SB5qC6BLpg8xmEMSiyw6qgBo=
   dependencies:
     tmpl "1.0.5"
@@ -5861,7 +5861,7 @@ micromatch@^3.1.10, micromatch@^3.1.4:
 
 micromatch@^4.0.4:
   version "4.0.4"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/micromatch/-/micromatch-4.0.4.tgz"
+  resolved "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz"
   integrity sha1-iW1Rnf6dsl/OlM63pQCRm/iB6/k=
   dependencies:
     braces "^3.0.1"
@@ -5869,12 +5869,12 @@ micromatch@^4.0.4:
 
 mime-db@1.52.0:
   version "1.52.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/mime-db/-/mime-db-1.52.0.tgz"
+  resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz"
   integrity sha1-u6vNwChZ9JhzAchW4zh85exDv3A=
 
 mime-types@^2.1.12, mime-types@^2.1.27:
   version "2.1.35"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/mime-types/-/mime-types-2.1.35.tgz"
+  resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz"
   integrity sha1-OBqHG2KnNEUGYK497uRIE/cNlZo=
   dependencies:
     mime-db "1.52.0"
@@ -5891,7 +5891,7 @@ mimic-response@^1.0.0:
 
 mimic-response@^3.1.0:
   version "3.1.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/mimic-response/-/mimic-response-3.1.0.tgz"
+  resolved "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz"
   integrity sha1-LR1Zr5wbEpgVrMwsRqAipc4fo8k=
 
 mini-css-extract-plugin@^1.3.3:
@@ -5912,7 +5912,7 @@ minimatch@^3.0.4, minimatch@~3.0.2:
 
 minimatch@^3.1.1:
   version "3.1.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/minimatch/-/minimatch-3.1.2.tgz"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
   integrity sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s=
   dependencies:
     brace-expansion "^1.1.7"
@@ -5924,7 +5924,7 @@ minimist@1.1.x:
 
 minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.6"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/minimist/-/minimist-1.2.6.tgz"
+  resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz"
   integrity sha1-hjelt1nqDW6YcCz7OpKDMjyTr0Q=
 
 mixin-deep@^1.2.0:
@@ -5937,7 +5937,7 @@ mixin-deep@^1.2.0:
 
 mkdirp@1.0.4, mkdirp@^1.0.3:
   version "1.0.4"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/mkdirp/-/mkdirp-1.0.4.tgz"
+  resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz"
   integrity sha1-PrXtYmInVteaXw4qIh3+utdcL34=
 
 mkdirp@^0.5.0, mkdirp@^0.5.1:
@@ -5959,7 +5959,7 @@ ms@2.0.0:
 
 ms@2.1.2:
   version "2.1.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/ms/-/ms-2.1.2.tgz"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   integrity sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=
 
 ms@^2.1.1:
@@ -5969,14 +5969,14 @@ ms@^2.1.1:
 
 multi-stage-sourcemap@^0.3.1:
   version "0.3.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/multi-stage-sourcemap/-/multi-stage-sourcemap-0.3.1.tgz"
+  resolved "https://registry.npmjs.org/multi-stage-sourcemap/-/multi-stage-sourcemap-0.3.1.tgz"
   integrity sha1-NbseBlXLAiUW6fktc4wHoqrP7sA=
   dependencies:
     source-map "^0.1.34"
 
 multimatch@5.0.0, multimatch@^5.0.0:
   version "5.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/multimatch/-/multimatch-5.0.0.tgz"
+  resolved "https://registry.npmjs.org/multimatch/-/multimatch-5.0.0.tgz"
   integrity sha1-kyuACWPOp6MaAzMo+h4MOhh02+Y=
   dependencies:
     "@types/minimatch" "^3.0.3"
@@ -5992,7 +5992,7 @@ mute-stream@0.0.5:
 
 nanoid@^3.3.4:
   version "3.3.4"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/nanoid/-/nanoid-3.3.4.tgz"
+  resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz"
   integrity sha1-cwtn480J4t6s8DwCfIHJ2dvF6Ks=
 
 nanomatch@^1.2.9:
@@ -6049,7 +6049,7 @@ node-environment-flags@^1.0.5:
 
 node-fetch@^2.6.7:
   version "2.6.7"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/node-fetch/-/node-fetch-2.6.7.tgz"
+  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz"
   integrity sha1-JN6fuoJ+O0rkTciyAlajeRYAUq0=
   dependencies:
     whatwg-url "^5.0.0"
@@ -6071,12 +6071,12 @@ node-releases@^1.1.71:
 
 node-releases@^2.0.6:
   version "2.0.6"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/node-releases/-/node-releases-2.0.6.tgz"
+  resolved "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz"
   integrity sha1-inCIxjpV5JOEVoPr88go2MUcVQM=
 
 node-stream-zip@^1.15.0:
   version "1.15.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/node-stream-zip/-/node-stream-zip-1.15.0.tgz"
+  resolved "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.15.0.tgz"
   integrity sha1-FYrbiO2ABMbEmjlrUKal3jvKM+o=
 
 normalize-package-data@^2.3.2:
@@ -6103,12 +6103,12 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
 
 normalize-url@^6.0.1:
   version "6.1.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/normalize-url/-/normalize-url-6.1.0.tgz"
+  resolved "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz"
   integrity sha1-QNCIW1Nd7/4/MUe+yHfQX+TFZoo=
 
 npm-run-path@^4.0.1:
   version "4.0.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/npm-run-path/-/npm-run-path-4.0.1.tgz"
+  resolved "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz"
   integrity sha1-t+zR5e1T2o43pV4cImnguX7XSOo=
   dependencies:
     path-key "^3.0.0"
@@ -6120,7 +6120,7 @@ number-is-nan@^1.0.0:
 
 nwsapi@^2.2.0:
   version "2.2.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/nwsapi/-/nwsapi-2.2.1.tgz#10a9f268fbf4c461249ebcfe38e359aa36e2577c"
+  resolved "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.1.tgz#10a9f268fbf4c461249ebcfe38e359aa36e2577c"
   integrity sha1-EKnyaPv0xGEknrz+OONZqjbiV3w=
 
 object-assign@^4.0.1, object-assign@^4.1.0:
@@ -6139,7 +6139,7 @@ object-copy@^0.1.0:
 
 object-inspect@^1.12.0:
   version "1.12.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/object-inspect/-/object-inspect-1.12.2.tgz#c0641f26394532f28ab8d796ab954e43c009a8ea"
+  resolved "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz#c0641f26394532f28ab8d796ab954e43c009a8ea"
   integrity sha1-wGQfJjlFMvKKuNeWq5VOQ8AJqOo=
 
 object-inspect@^1.9.0:
@@ -6149,7 +6149,7 @@ object-inspect@^1.9.0:
 
 object-is@^1.0.1:
   version "1.1.5"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/object-is/-/object-is-1.1.5.tgz#b9deeaa5fc7f1846a0faecdceec138e5778f53ac"
+  resolved "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz#b9deeaa5fc7f1846a0faecdceec138e5778f53ac"
   integrity sha1-ud7qpfx/GEag+uzc7sE45XePU6w=
   dependencies:
     call-bind "^1.0.2"
@@ -6227,14 +6227,14 @@ onetime@^1.0.0:
 
 onetime@^5.1.2:
   version "5.1.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/onetime/-/onetime-5.1.2.tgz"
+  resolved "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz"
   integrity sha1-0Oluu1awdHbfHdnEgG5SN5hcpF4=
   dependencies:
     mimic-fn "^2.1.0"
 
 opencollective-postinstall@2.0.3:
   version "2.0.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz#7a0fff978f6dbfa4d006238fbac98ed4198c3259"
+  resolved "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz#7a0fff978f6dbfa4d006238fbac98ed4198c3259"
   integrity sha1-eg//l49tv6TQBiOPusmO1BmMMlk=
 
 optionator@^0.8.1:
@@ -6268,7 +6268,7 @@ os-homedir@^1.0.0:
 
 p-cancelable@^2.0.0:
   version "2.1.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/p-cancelable/-/p-cancelable-2.1.1.tgz"
+  resolved "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz"
   integrity sha1-qrf71BZYL6MqPbSYWcEiSHxe0s8=
 
 p-limit@^1.1.0:
@@ -6287,7 +6287,7 @@ p-limit@^2.0.0, p-limit@^2.2.0:
 
 p-limit@^3.1.0:
   version "3.1.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/p-limit/-/p-limit-3.1.0.tgz"
+  resolved "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz"
   integrity sha1-4drMvnjQ0TiMoYxk/qOOPlfjcGs=
   dependencies:
     yocto-queue "^0.1.0"
@@ -6340,7 +6340,7 @@ parse-json@^4.0.0:
 
 parse-json@^5.2.0:
   version "5.2.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/parse-json/-/parse-json-5.2.0.tgz"
+  resolved "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz"
   integrity sha1-x2/Gbe5UIxyWKyK8yKcs8vmXU80=
   dependencies:
     "@babel/code-frame" "^7.0.0"
@@ -6355,7 +6355,7 @@ parse-passwd@^1.0.0:
 
 parse5@6.0.1:
   version "6.0.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
+  resolved "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
   integrity sha1-4aHAhcVps9wIMhGE8Zo5zCf3wws=
 
 pascalcase@^0.1.1:
@@ -6395,7 +6395,7 @@ path-key@^3.0.0, path-key@^3.1.0:
 
 path-parse@^1.0.6, path-parse@^1.0.7:
   version "1.0.7"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/path-parse/-/path-parse-1.0.7.tgz"
+  resolved "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz"
   integrity sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU=
 
 path-to-regexp@^1.7.0:
@@ -6419,7 +6419,7 @@ pathval@^1.1.1:
 
 picocolors@^1.0.0:
   version "1.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/picocolors/-/picocolors-1.0.0.tgz"
+  resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz"
   integrity sha1-y1vcdP8/UYkiNur3nWi8RFZKuBw=
 
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3:
@@ -6451,7 +6451,7 @@ pirates@^4.0.0:
 
 pirates@^4.0.4:
   version "4.0.5"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/pirates/-/pirates-4.0.5.tgz"
+  resolved "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz"
   integrity sha1-/uw1LqXDJo+yOjfHAqsWmfNaXzs=
 
 pkg-dir@^2.0.0:
@@ -6535,12 +6535,12 @@ postcss-value-parser@^4.1.0:
 
 postcss-value-parser@^4.2.0:
   version "4.2.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz"
+  resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz"
   integrity sha1-cjwJkgg2um0+WvAZ+SvAlxwC5RQ=
 
 postcss@^8.4.7:
   version "8.4.14"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/postcss/-/postcss-8.4.14.tgz"
+  resolved "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz"
   integrity sha1-7pJ01WIrSFjBAHp0125C5W/SHK8=
   dependencies:
     nanoid "^3.3.4"
@@ -6559,17 +6559,17 @@ prelude-ls@~1.1.2:
 
 prettier@^1.19.1:
   version "1.19.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/prettier/-/prettier-1.19.1.tgz"
+  resolved "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz"
   integrity sha1-99f1/4qc2HKnvkyhQglZVqYHl8s=
 
 prettier@^2.5.1:
   version "2.7.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/prettier/-/prettier-2.7.1.tgz"
+  resolved "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz"
   integrity sha1-4jWAaFDQV/l7sINopPfYmfd2DGQ=
 
 pretty-format@^28.1.3:
   version "28.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/pretty-format/-/pretty-format-28.1.3.tgz"
+  resolved "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.3.tgz"
   integrity sha1-yfuozt+ZzlCWOhGyfZgqmukJcNU=
   dependencies:
     "@jest/schemas" "^28.1.3"
@@ -6584,7 +6584,7 @@ process-nextick-args@~2.0.0:
 
 process@0.11.10:
   version "0.11.10"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
+  resolved "https://registry.npmjs.org/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
 progress@^1.1.8:
@@ -6607,7 +6607,7 @@ prompts@^2.0.1:
 
 psl@^1.1.33:
   version "1.9.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
+  resolved "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
   integrity sha1-0N8qE38AeUVl/K87LADNCfjVpac=
 
 pump@^3.0.0:
@@ -6625,7 +6625,7 @@ punycode@^2.1.0, punycode@^2.1.1:
 
 quick-lru@^5.1.1:
   version "5.1.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/quick-lru/-/quick-lru-5.1.1.tgz"
+  resolved "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz"
   integrity sha1-NmST5rPkKjpoheLpnRj4D7eoyTI=
 
 randombytes@^2.1.0:
@@ -6637,7 +6637,7 @@ randombytes@^2.1.0:
 
 react-is@^18.0.0:
   version "18.2.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/react-is/-/react-is-18.2.0.tgz"
+  resolved "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz"
   integrity sha1-GZQx7qqi4J+GQn77tPFHPttHYJs=
 
 read-pkg-up@^3.0.0:
@@ -6697,7 +6697,7 @@ readdirp@~3.5.0:
 
 readdirp@~3.6.0:
   version "3.6.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
+  resolved "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
   integrity sha1-dKNwvYVxFuJFspzJc0DNQxoCpsc=
   dependencies:
     picomatch "^2.2.1"
@@ -6720,14 +6720,14 @@ rechoir@^0.6.2:
 
 rechoir@^0.7.0:
   version "0.7.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/rechoir/-/rechoir-0.7.1.tgz"
+  resolved "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz"
   integrity sha1-lHipahyhNbXoj8An8D7pLWxkVoY=
   dependencies:
     resolve "^1.9.0"
 
 reflect-metadata@0.1.13:
   version "0.1.13"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
+  resolved "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
   integrity sha1-Z648pXyXKiqhZCsQ/jY/4y1J3Ag=
 
 regenerate-unicode-properties@^8.2.0:
@@ -6764,7 +6764,7 @@ regex-not@^1.0.0, regex-not@^1.0.2:
 
 regexp.prototype.flags@^1.4.3:
   version "1.4.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz#87cab30f80f66660181a3bb7bf5981a872b367ac"
+  resolved "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz#87cab30f80f66660181a3bb7bf5981a872b367ac"
   integrity sha1-h8qzD4D2ZmAYGju3v1mBqHKzZ6w=
   dependencies:
     call-bind "^1.0.2"
@@ -6840,7 +6840,7 @@ require-uncached@^1.0.2:
 
 resolve-alpn@^1.0.0:
   version "1.2.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/resolve-alpn/-/resolve-alpn-1.2.1.tgz"
+  resolved "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz"
   integrity sha1-t629rDVGqq7CC0Xn2CZZJwcnJvk=
 
 resolve-cwd@^3.0.0:
@@ -6872,7 +6872,7 @@ resolve-url@^0.2.1:
 
 resolve.exports@^1.1.0:
   version "1.1.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/resolve.exports/-/resolve.exports-1.1.0.tgz"
+  resolved "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.0.tgz"
   integrity sha1-XOhCuUsFFGwOAwdphdHQ5+SMkMk=
 
 resolve@^1.1.6, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.20.0:
@@ -6885,7 +6885,7 @@ resolve@^1.1.6, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14
 
 resolve@^1.9.0:
   version "1.22.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/resolve/-/resolve-1.22.1.tgz"
+  resolved "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz"
   integrity sha1-J8suu1P5GrtJRwqSi7p1WAZqwXc=
   dependencies:
     is-core-module "^2.9.0"
@@ -6894,7 +6894,7 @@ resolve@^1.9.0:
 
 responselike@^2.0.0:
   version "2.0.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/responselike/-/responselike-2.0.1.tgz"
+  resolved "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz"
   integrity sha1-mgvI/cJS8/scymiwFlkQWboUIrw=
   dependencies:
     lowercase-keys "^2.0.0"
@@ -7000,7 +7000,7 @@ sass-loader@^8.0.0:
 
 sass@^1.53.0:
   version "1.53.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/sass/-/sass-1.53.0.tgz#eab73a7baac045cc57ddc1d1ff501ad2659952eb"
+  resolved "https://registry.npmjs.org/sass/-/sass-1.53.0.tgz#eab73a7baac045cc57ddc1d1ff501ad2659952eb"
   integrity sha1-6rc6e6rARcxX3cHR/1Aa0mWZUus=
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
@@ -7009,7 +7009,7 @@ sass@^1.53.0:
 
 saxes@^5.0.1:
   version "5.0.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/saxes/-/saxes-5.0.1.tgz#eebab953fa3b7608dbe94e5dadb15c888fa6696d"
+  resolved "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz#eebab953fa3b7608dbe94e5dadb15c888fa6696d"
   integrity sha1-7rq5U/o7dgjb6U5drbFciI+maW0=
   dependencies:
     xmlchars "^2.2.0"
@@ -7034,7 +7034,7 @@ schema-utils@^3.0.0:
 
 schema-utils@^3.1.0, schema-utils@^3.1.1:
   version "3.1.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/schema-utils/-/schema-utils-3.1.1.tgz"
+  resolved "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz"
   integrity sha1-vHTEtraZXB2I92qLd76nIZ4MgoE=
   dependencies:
     "@types/json-schema" "^7.0.8"
@@ -7053,7 +7053,7 @@ semver@7.0.0:
 
 semver@7.3.2:
   version "7.3.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/semver/-/semver-7.3.2.tgz"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz"
   integrity sha1-YElisFK4HtB4aq6EOJ/7pw/9OTg=
 
 semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
@@ -7070,7 +7070,7 @@ semver@^7.2.1, semver@^7.3.5:
 
 serialize-javascript@^6.0.0:
   version "6.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/serialize-javascript/-/serialize-javascript-6.0.0.tgz"
+  resolved "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz"
   integrity sha1-765diPRdeSQUHai1w6en5mP+/rg=
   dependencies:
     randombytes "^2.1.0"
@@ -7132,7 +7132,7 @@ shelljs@^0.8.4:
 
 side-channel@^1.0.4:
   version "1.0.4"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
+  resolved "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
   integrity sha1-785cj9wQTudRslxY1CkAEfpeos8=
   dependencies:
     call-bind "^1.0.0"
@@ -7141,12 +7141,12 @@ side-channel@^1.0.4:
 
 signal-exit@^3.0.3:
   version "3.0.4"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/signal-exit/-/signal-exit-3.0.4.tgz"
+  resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.4.tgz"
   integrity sha1-NmpGhNF1ucqyCB42gf2jdHtsUdc=
 
 signal-exit@^3.0.7:
   version "3.0.7"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/signal-exit/-/signal-exit-3.0.7.tgz"
+  resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz"
   integrity sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=
 
 sinon-chai@^3.4.0:
@@ -7233,7 +7233,7 @@ source-list-map@^2.0.0, source-list-map@^2.0.1:
 
 "source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.0.2:
   version "1.0.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/source-map-js/-/source-map-js-1.0.2.tgz"
+  resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz"
   integrity sha1-rbw2HZxi3zgBJefxYfccgm8eSQw=
 
 source-map-loader@^1.0.2:
@@ -7261,7 +7261,7 @@ source-map-resolve@^0.5.0:
 
 source-map-support@0.5.13:
   version "0.5.13"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/source-map-support/-/source-map-support-0.5.13.tgz"
+  resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz"
   integrity sha1-MbJKnC5zwt6FBmwP631Edn7VKTI=
   dependencies:
     buffer-from "^1.0.0"
@@ -7269,7 +7269,7 @@ source-map-support@0.5.13:
 
 source-map-support@0.5.21, source-map-support@~0.5.20:
   version "0.5.21"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/source-map-support/-/source-map-support-0.5.21.tgz"
+  resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz"
   integrity sha1-BP58f54e0tZiIzwoyys1ufY/bk8=
   dependencies:
     buffer-from "^1.0.0"
@@ -7350,7 +7350,7 @@ sprintf-js@~1.0.2:
 
 stack-utils@^2.0.3:
   version "2.0.5"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/stack-utils/-/stack-utils-2.0.5.tgz"
+  resolved "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz"
   integrity sha1-0lJl/KmVFUZZ27+6O0klR3jS/dU=
   dependencies:
     escape-string-regexp "^2.0.0"
@@ -7373,7 +7373,7 @@ string-length@^4.0.1:
 
 string-template@1.0.0:
   version "1.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/string-template/-/string-template-1.0.0.tgz#9e9f2233dc00f218718ec379a28a5673ecca8b96"
+  resolved "https://registry.npmjs.org/string-template/-/string-template-1.0.0.tgz#9e9f2233dc00f218718ec379a28a5673ecca8b96"
   integrity sha1-np8iM9wA8hhxjsN5oopWc+zKi5Y=
 
 string-width@^1.0.1:
@@ -7413,7 +7413,7 @@ string-width@^4.1.0, string-width@^4.2.0:
 
 string-width@^4.2.3:
   version "4.2.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/string-width/-/string-width-4.2.3.tgz"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=
   dependencies:
     emoji-regex "^8.0.0"
@@ -7430,7 +7430,7 @@ string.prototype.trimend@^1.0.4:
 
 string.prototype.trimend@^1.0.5:
   version "1.0.5"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz#914a65baaab25fbdd4ee291ca7dde57e869cb8d0"
+  resolved "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz#914a65baaab25fbdd4ee291ca7dde57e869cb8d0"
   integrity sha1-kUpluqqyX73U7ikcp93lfoacuNA=
   dependencies:
     call-bind "^1.0.2"
@@ -7447,7 +7447,7 @@ string.prototype.trimstart@^1.0.4:
 
 string.prototype.trimstart@^1.0.5:
   version "1.0.5"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz#5466d93ba58cfa2134839f81d7f42437e8c01fef"
+  resolved "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz#5466d93ba58cfa2134839f81d7f42437e8c01fef"
   integrity sha1-VGbZO6WM+iE0g5+B1/QkN+jAH+8=
   dependencies:
     call-bind "^1.0.2"
@@ -7463,7 +7463,7 @@ string_decoder@~1.1.1:
 
 stringz@2.1.0:
   version "2.1.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/stringz/-/stringz-2.1.0.tgz#5896b4713eac31157556040fb90258fb02c1630c"
+  resolved "https://registry.npmjs.org/stringz/-/stringz-2.1.0.tgz#5896b4713eac31157556040fb90258fb02c1630c"
   integrity sha1-WJa0cT6sMRV1VgQPuQJY+wLBYww=
   dependencies:
     char-regex "^1.0.2"
@@ -7498,7 +7498,7 @@ strip-ansi@^6.0.0:
 
 strip-ansi@^6.0.1:
   version "6.0.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/strip-ansi/-/strip-ansi-6.0.1.tgz"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=
   dependencies:
     ansi-regex "^5.0.1"
@@ -7535,7 +7535,7 @@ supports-color@^2.0.0:
 
 supports-color@^5.3.0:
   version "5.5.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/supports-color/-/supports-color-5.5.0.tgz"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz"
   integrity sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=
   dependencies:
     has-flag "^3.0.0"
@@ -7556,7 +7556,7 @@ supports-color@^7.0.0, supports-color@^7.1.0:
 
 supports-color@^8.0.0:
   version "8.1.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/supports-color/-/supports-color-8.1.1.tgz"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz"
   integrity sha1-zW/BfihQDP9WwbhsCn/UpUpzAFw=
   dependencies:
     has-flag "^4.0.0"
@@ -7571,12 +7571,12 @@ supports-hyperlinks@^2.0.0:
 
 supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz"
+  resolved "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz"
   integrity sha1-btpL00SjyUrqN21MwxvHcxEDngk=
 
 symbol-tree@^3.2.4:
   version "3.2.4"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
+  resolved "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha1-QwY30ki6d+B4iDlR+5qg7tfGP6I=
 
 table@^3.7.8:
@@ -7605,7 +7605,7 @@ table@^6.0.9:
 
 table@^6.7.3:
   version "6.8.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/table/-/table-6.8.0.tgz"
+  resolved "https://registry.npmjs.org/table/-/table-6.8.0.tgz"
   integrity sha1-h+KPFPpDIcM3e6KG8Ht5soGjs8o=
   dependencies:
     ajv "^8.0.1"
@@ -7616,7 +7616,7 @@ table@^6.7.3:
 
 tapable@^2.1.1, tapable@^2.2.0:
   version "2.2.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/tapable/-/tapable-2.2.1.tgz"
+  resolved "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz"
   integrity sha1-GWenPvQGCoLxKrlq+G1S/bdu7KA=
 
 terminal-link@^2.0.0:
@@ -7629,7 +7629,7 @@ terminal-link@^2.0.0:
 
 terser-webpack-plugin@^5.1.3, terser-webpack-plugin@^5.3.3:
   version "5.3.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/terser-webpack-plugin/-/terser-webpack-plugin-5.3.3.tgz"
+  resolved "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.3.tgz"
   integrity sha1-gDPbh23Vh1SHIT6Hxie8oyPl7ZA=
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.7"
@@ -7640,7 +7640,7 @@ terser-webpack-plugin@^5.1.3, terser-webpack-plugin@^5.3.3:
 
 terser@^5.7.2:
   version "5.14.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/terser/-/terser-5.14.2.tgz"
+  resolved "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz"
   integrity sha1-msnyKwaZTXNhdPQJGqNo24lvHBA=
   dependencies:
     "@jridgewell/source-map" "^0.3.2"
@@ -7664,7 +7664,7 @@ text-table@^0.2.0, text-table@~0.2.0:
 
 three@^0.142.0:
   version "0.142.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/three/-/three-0.142.0.tgz"
+  resolved "https://registry.npmjs.org/three/-/three-0.142.0.tgz"
   integrity sha1-ieImoWIh8hLrHUDweGYEtxHyiu0=
 
 through@^2.3.6:
@@ -7674,12 +7674,12 @@ through@^2.3.6:
 
 tmpl@1.0.5:
   version "1.0.5"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/tmpl/-/tmpl-1.0.5.tgz"
+  resolved "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz"
   integrity sha1-hoPguQK7nCDE9ybjwLafNlGMB8w=
 
 to-fast-properties@^2.0.0:
   version "2.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/to-fast-properties/-/to-fast-properties-2.0.0.tgz"
+  resolved "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz"
   integrity sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=
 
 to-object-path@^0.3.0:
@@ -7716,7 +7716,7 @@ to-regex@^3.0.1, to-regex@^3.0.2:
 
 tough-cookie@^4.0.0:
   version "4.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/tough-cookie/-/tough-cookie-4.0.0.tgz#d822234eeca882f991f0f908824ad2622ddbece4"
+  resolved "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz#d822234eeca882f991f0f908824ad2622ddbece4"
   integrity sha1-2CIjTuyogvmR8PkIgkrSYi3b7OQ=
   dependencies:
     psl "^1.1.33"
@@ -7725,14 +7725,14 @@ tough-cookie@^4.0.0:
 
 tr46@^3.0.0:
   version "3.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/tr46/-/tr46-3.0.0.tgz#555c4e297a950617e8eeddef633c87d4d9d6cbf9"
+  resolved "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz#555c4e297a950617e8eeddef633c87d4d9d6cbf9"
   integrity sha1-VVxOKXqVBhfo7t3vYzyH1NnWy/k=
   dependencies:
     punycode "^2.1.1"
 
 tr46@~0.0.3:
   version "0.0.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/tr46/-/tr46-0.0.3.tgz"
+  resolved "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz"
   integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
 
 tree-kill@^1.2.2:
@@ -7752,7 +7752,7 @@ tsconfig-paths@^3.9.0:
 
 tslib@2.3.1:
   version "2.3.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha1-6KM1rdXOrlGqJh0ypJAVjvBC7wE=
 
 tslib@^1.9.0:
@@ -7816,7 +7816,7 @@ typescript-compiler@^1.4.1-2:
 
 typescript@~4.4.4:
   version "4.4.4"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/typescript/-/typescript-4.4.4.tgz"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz"
   integrity sha1-LNAaGh8WBwTTEB/VpY/w+fy4Aww=
 
 unbox-primitive@^1.0.0:
@@ -7831,7 +7831,7 @@ unbox-primitive@^1.0.0:
 
 unbox-primitive@^1.0.2:
   version "1.0.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/unbox-primitive/-/unbox-primitive-1.0.2.tgz#29032021057d5e6cdbd08c5129c226dff8ed6f9e"
+  resolved "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz#29032021057d5e6cdbd08c5129c226dff8ed6f9e"
   integrity sha1-KQMgIQV9Xmzb0IxRKcIm3/jtb54=
   dependencies:
     call-bind "^1.0.2"
@@ -7874,7 +7874,7 @@ union-value@^1.0.0:
 
 universal-user-agent@^6.0.0:
   version "6.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/universal-user-agent/-/universal-user-agent-6.0.0.tgz"
+  resolved "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz"
   integrity sha1-M4H4UDslHA2c0hvB3pOeyd9UgO4=
 
 universalify@^0.1.0, universalify@^0.1.2:
@@ -7897,7 +7897,7 @@ upath@^1.1.1:
 
 update-browserslist-db@^1.0.4:
   version "1.0.5"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz"
+  resolved "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz"
   integrity sha1-vgal7t1i8Qe3wZ61vO+xlEEavzg=
   dependencies:
     escalade "^3.1.1"
@@ -7946,7 +7946,7 @@ util@^0.10.3:
 
 util@^0.12.0:
   version "0.12.4"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/util/-/util-0.12.4.tgz#66121a31420df8f01ca0c464be15dfa1d1850253"
+  resolved "https://registry.npmjs.org/util/-/util-0.12.4.tgz#66121a31420df8f01ca0c464be15dfa1d1850253"
   integrity sha1-ZhIaMUIN+PAcoMRkvhXfodGFAlM=
   dependencies:
     inherits "^2.0.3"
@@ -7968,7 +7968,7 @@ v8-compile-cache@^2.0.3:
 
 v8-to-istanbul@^9.0.1:
   version "9.0.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/v8-to-istanbul/-/v8-to-istanbul-9.0.1.tgz"
+  resolved "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.0.1.tgz"
   integrity sha1-tvmUsLXU7yVeF6DRfcREqfUTL6Q=
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.12"
@@ -7992,40 +7992,40 @@ validate-npm-package-license@^3.0.1:
 
 validator@^13.7.0:
   version "13.7.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/validator/-/validator-13.7.0.tgz#4f9658ba13ba8f3d82ee881d3516489ea85c0857"
+  resolved "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz#4f9658ba13ba8f3d82ee881d3516489ea85c0857"
   integrity sha1-T5ZYuhO6jz2C7ogdNRZInqhcCFc=
 
 vanilla-picker@^2.12.1:
   version "2.12.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/vanilla-picker/-/vanilla-picker-2.12.1.tgz"
+  resolved "https://registry.npmjs.org/vanilla-picker/-/vanilla-picker-2.12.1.tgz"
   integrity sha1-bmGe7PVTiRuNLQQrdFojyR8Z80w=
   dependencies:
     "@sphinxxxx/color-conversion" "^2.2.2"
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz#0a89cdf5cc15822df9c360543676963e0cc308cd"
+  resolved "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz#0a89cdf5cc15822df9c360543676963e0cc308cd"
   integrity sha1-ConN9cwVgi35w2BUNnaWPgzDCM0=
   dependencies:
     browser-process-hrtime "^1.0.0"
 
 w3c-xmlserializer@^3.0.0:
   version "3.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/w3c-xmlserializer/-/w3c-xmlserializer-3.0.0.tgz#06cdc3eefb7e4d0b20a560a5a3aeb0d2d9a65923"
+  resolved "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-3.0.0.tgz#06cdc3eefb7e4d0b20a560a5a3aeb0d2d9a65923"
   integrity sha1-Bs3D7vt+TQsgpWClo66w0tmmWSM=
   dependencies:
     xml-name-validator "^4.0.0"
 
 walker@^1.0.8:
   version "1.0.8"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/walker/-/walker-1.0.8.tgz"
+  resolved "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz"
   integrity sha1-vUmNtHev5XPcBBhfAR06uKjXZT8=
   dependencies:
     makeerror "1.0.12"
 
 watchpack@^2.3.1:
   version "2.4.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/watchpack/-/watchpack-2.4.0.tgz"
+  resolved "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz"
   integrity sha1-+jMDI3SWLHgRP5PH8vtMVMmGKl0=
   dependencies:
     glob-to-regexp "^0.4.1"
@@ -8033,17 +8033,17 @@ watchpack@^2.3.1:
 
 webidl-conversions@^3.0.0:
   version "3.0.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/webidl-conversions/-/webidl-conversions-3.0.1.tgz"
+  resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz"
   integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
 
 webidl-conversions@^7.0.0:
   version "7.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
+  resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
   integrity sha1-JWtOGIK+feu/AdBfCqIDl3jqCAo=
 
 webpack-cli@^4.10.0:
   version "4.10.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/webpack-cli/-/webpack-cli-4.10.0.tgz"
+  resolved "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz"
   integrity sha1-N8HWnI2FIUxaZeWJN49TrsZNqzE=
   dependencies:
     "@discoveryjs/json-ext" "^0.5.0"
@@ -8061,7 +8061,7 @@ webpack-cli@^4.10.0:
 
 webpack-merge@^5.7.3:
   version "5.8.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/webpack-merge/-/webpack-merge-5.8.0.tgz"
+  resolved "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz"
   integrity sha1-Kznb8ir4d3atdEw5AiNzHTCmj2E=
   dependencies:
     clone-deep "^4.0.1"
@@ -8069,7 +8069,7 @@ webpack-merge@^5.7.3:
 
 webpack-obfuscator@^3.5.1:
   version "3.5.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/webpack-obfuscator/-/webpack-obfuscator-3.5.1.tgz"
+  resolved "https://registry.npmjs.org/webpack-obfuscator/-/webpack-obfuscator-3.5.1.tgz"
   integrity sha1-itc3RfLXyOR26PcAYi0lH97sdMI=
   dependencies:
     loader-utils "^2.0.0"
@@ -8087,7 +8087,7 @@ webpack-sources@^1.1.0:
 
 webpack-sources@^2.0.1:
   version "2.3.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/webpack-sources/-/webpack-sources-2.3.1.tgz"
+  resolved "https://registry.npmjs.org/webpack-sources/-/webpack-sources-2.3.1.tgz"
   integrity sha1-Vw3grxY5Sf4nIjPCzv4bVvdFEf0=
   dependencies:
     source-list-map "^2.0.1"
@@ -8095,12 +8095,12 @@ webpack-sources@^2.0.1:
 
 webpack-sources@^3.2.3:
   version "3.2.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/webpack-sources/-/webpack-sources-3.2.3.tgz"
+  resolved "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz"
   integrity sha1-LU2quEUf1LJAzCcFX/agwszqDN4=
 
 webpack@^5.73.0:
   version "5.73.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/webpack/-/webpack-5.73.0.tgz"
+  resolved "https://registry.npmjs.org/webpack/-/webpack-5.73.0.tgz"
   integrity sha1-u9F3OPilPuV2DqL1nc5/NDHTXTg=
   dependencies:
     "@types/eslint-scope" "^3.7.3"
@@ -8130,7 +8130,7 @@ webpack@^5.73.0:
 
 whatwg-encoding@^2.0.0:
   version "2.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz#e7635f597fd87020858626805a2729fa7698ac53"
+  resolved "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz#e7635f597fd87020858626805a2729fa7698ac53"
   integrity sha1-52NfWX/YcCCFhiaAWicp+naYrFM=
   dependencies:
     iconv-lite "0.6.3"
@@ -8142,12 +8142,12 @@ whatwg-mimetype@^2.3.0:
 
 whatwg-mimetype@^3.0.0:
   version "3.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz#5fa1a7623867ff1af6ca3dc72ad6b8a4208beba7"
+  resolved "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz#5fa1a7623867ff1af6ca3dc72ad6b8a4208beba7"
   integrity sha1-X6GnYjhn/xr2yj3HKta4pCCL66c=
 
 whatwg-url@^10.0.0:
   version "10.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/whatwg-url/-/whatwg-url-10.0.0.tgz#37264f720b575b4a311bd4094ed8c760caaa05da"
+  resolved "https://registry.npmjs.org/whatwg-url/-/whatwg-url-10.0.0.tgz#37264f720b575b4a311bd4094ed8c760caaa05da"
   integrity sha1-NyZPcgtXW0oxG9QJTtjHYMqqBdo=
   dependencies:
     tr46 "^3.0.0"
@@ -8155,7 +8155,7 @@ whatwg-url@^10.0.0:
 
 whatwg-url@^11.0.0:
   version "11.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/whatwg-url/-/whatwg-url-11.0.0.tgz#0a849eebb5faf2119b901bb76fd795c2848d4018"
+  resolved "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz#0a849eebb5faf2119b901bb76fd795c2848d4018"
   integrity sha1-CoSe67X68hGbkBu3b9eVwoSNQBg=
   dependencies:
     tr46 "^3.0.0"
@@ -8163,7 +8163,7 @@ whatwg-url@^11.0.0:
 
 whatwg-url@^5.0.0:
   version "5.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/whatwg-url/-/whatwg-url-5.0.0.tgz"
+  resolved "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz"
   integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
   dependencies:
     tr46 "~0.0.3"
@@ -8187,7 +8187,7 @@ which-module@^2.0.0:
 
 which-typed-array@^1.1.2:
   version "1.1.8"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/which-typed-array/-/which-typed-array-1.1.8.tgz#0cfd53401a6f334d90ed1125754a42ed663eb01f"
+  resolved "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.8.tgz#0cfd53401a6f334d90ed1125754a42ed663eb01f"
   integrity sha1-DP1TQBpvM02Q7REldUpC7WY+sB8=
   dependencies:
     available-typed-arrays "^1.0.5"
@@ -8206,7 +8206,7 @@ which@^2.0.1, which@^2.0.2:
 
 wildcard@^2.0.0:
   version "2.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/wildcard/-/wildcard-2.0.0.tgz"
+  resolved "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz"
   integrity sha1-p30g5SAMb6qsl55LOq3Hs91/j+w=
 
 word-wrap@^1.2.3, word-wrap@~1.2.3:
@@ -8225,7 +8225,7 @@ wrap-ansi@^5.1.0:
 
 wrap-ansi@^6.2.0:
   version "6.2.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/wrap-ansi/-/wrap-ansi-6.2.0.tgz"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz"
   integrity sha1-6Tk7oHEC5skaOyIUePAlfNKFblM=
   dependencies:
     ansi-styles "^4.0.0"
@@ -8234,7 +8234,7 @@ wrap-ansi@^6.2.0:
 
 wrap-ansi@^7.0.0:
   version "7.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=
   dependencies:
     ansi-styles "^4.0.0"
@@ -8248,7 +8248,7 @@ wrappy@1:
 
 write-file-atomic@^4.0.1:
   version "4.0.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/write-file-atomic/-/write-file-atomic-4.0.1.tgz"
+  resolved "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.1.tgz"
   integrity sha1-n6ozqWTByF/2+Em4C0KojCxTfI8=
   dependencies:
     imurmurhash "^0.1.4"
@@ -8263,17 +8263,17 @@ write@^0.2.1:
 
 ws@^8.2.3:
   version "8.8.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/ws/-/ws-8.8.1.tgz#5dbad0feb7ade8ecc99b830c1d77c913d4955ff0"
+  resolved "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz#5dbad0feb7ade8ecc99b830c1d77c913d4955ff0"
   integrity sha1-XbrQ/ret6OzJm4MMHXfJE9SVX/A=
 
 xml-name-validator@^4.0.0:
   version "4.0.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/xml-name-validator/-/xml-name-validator-4.0.0.tgz#79a006e2e63149a8600f15430f0a4725d1524835"
+  resolved "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz#79a006e2e63149a8600f15430f0a4725d1524835"
   integrity sha1-eaAG4uYxSahgDxVDDwpHJdFSSDU=
 
 xmlchars@^2.2.0:
   version "2.2.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
+  resolved "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha1-Bg/hvLf5x2/ioX24apvDq4lCEMs=
 
 xtend@^4.0.0:
@@ -8288,7 +8288,7 @@ y18n@^4.0.0:
 
 y18n@^5.0.5:
   version "5.0.8"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/y18n/-/y18n-5.0.8.tgz"
+  resolved "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz"
   integrity sha1-f0k00PfKjFb5UxSTndzS3ZHOHVU=
 
 yallist@^4.0.0:
@@ -8306,7 +8306,7 @@ yargs-parser@^13.1.2:
 
 yargs-parser@^18.1.2:
   version "18.1.3"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/yargs-parser/-/yargs-parser-18.1.3.tgz"
+  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz"
   integrity sha1-vmjEl1xrKr9GkjawyHA2L6sJp7A=
   dependencies:
     camelcase "^5.0.0"
@@ -8314,7 +8314,7 @@ yargs-parser@^18.1.2:
 
 yargs-parser@^21.0.0:
   version "21.0.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/yargs-parser/-/yargs-parser-21.0.1.tgz"
+  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz"
   integrity sha1-Amfyhsh3pPD3KPzrb4o+TLlcbjU=
 
 yargs@^13.3.0:
@@ -8335,7 +8335,7 @@ yargs@^13.3.0:
 
 yargs@^15.1.0:
   version "15.4.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/yargs/-/yargs-15.4.1.tgz"
+  resolved "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz"
   integrity sha1-DYehbeAa7p2L7Cv7909nhRcw9Pg=
   dependencies:
     cliui "^6.0.0"
@@ -8352,7 +8352,7 @@ yargs@^15.1.0:
 
 yargs@^17.3.1:
   version "17.5.1"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/yargs/-/yargs-17.5.1.tgz"
+  resolved "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz"
   integrity sha1-4QmQDKtvy3/USx2CSRZv6ws25Y4=
   dependencies:
     cliui "^7.0.2"
@@ -8365,5 +8365,5 @@ yargs@^17.3.1:
 
 yocto-queue@^0.1.0:
   version "0.1.0"
-  resolved "https://artifactory.virt.ch.bbc.co.uk:443/artifactory/api/npm/cosmos-npm/yocto-queue/-/yocto-queue-0.1.0.tgz"
+  resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz"
   integrity sha1-ApTrPe4FAo0x7hpfosVWpqrxChs=


### PR DESCRIPTION
# Details

Updates the lockfile references to the public NPM registry rather than BBC artifactory

# Ticket / issue URL
Ticket / issue URL: 

# PR Checks
(tick as appropriate) 

- [ ] PR is linked to ticket / issue
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [ ] PR has the package.json version bumped 
