### PR TITLE
feat: default export as esmodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Using the library
 
 > You'll notice the term "_romper_" appears frequently in the code, rather than StoryPlayer.  This is historical - the player was initially called Romper, an acronym for **R**&D **O**bject based **M**edia **P**lay**ER**.  The name was changed to better fit with the naming conventions of the StoryKit suite of tools, but _romper_ remains in many places in the code.
 
-The defaul export from [storyplayer.js](src/storyplayer.js) is a function that is used to initiate and return an instance of StoryPlayer. It takes one argument, defining the Player settings, which has the following attributes:
+The default export from [storyplayer.js](src/storyplayer.js) is a function that is used to initiate and return an instance of StoryPlayer. It takes one argument, defining the Player settings, which has the following attributes:
 
 * `target` - An HTML element for the player to live in.
 * fetchers - functions that take a UUID and return an Object describing an instance of the data model for the given experience.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Using the library
 
 > You'll notice the term "_romper_" appears frequently in the code, rather than StoryPlayer.  This is historical - the player was initially called Romper, an acronym for **R**&D **O**bject based **M**edia **P**lay**ER**.  The name was changed to better fit with the naming conventions of the StoryKit suite of tools, but _romper_ remains in many places in the code.
 
-[storyplayer.js](src/storyplayer.js) exports an `init()` function that is used to initiate StoryPlayer and returns an instance of StoryPlayer.  It takes one argument, defining the Player settings, which has the following attributes:
+The defaul export from [storyplayer.js](src/storyplayer.js) is a function that is used to initiate and return an instance of StoryPlayer. It takes one argument, defining the Player settings, which has the following attributes:
 
 * `target` - An HTML element for the player to live in.
 * fetchers - functions that take a UUID and return an Object describing an instance of the data model for the given experience.
@@ -33,7 +33,7 @@ Using the library
 For example, in a React application import the player:
 
 ```
-import Storyplayer, { VARIABLE_EVENTS,  REASONER_EVENTS } from '@bbc/storyplayer';
+import StoryPlayer, { VARIABLE_EVENTS,  REASONER_EVENTS } from '@bbc/storyplayer';
 ```
 
 Initiate it using an Object with the attributes described above:
@@ -41,7 +41,7 @@ Initiate it using an Object with the attributes described above:
     const playerSettingsObject = {
         // an Object including the above attributes
     }
-    this.storyplayer = Storyplayer.init(playerSettingsObject);
+    this.storyplayer = StoryPlayer(playerSettingsObject);
 ```
 
 The returned instance will fire events that can be listened for and handled.  For example:
@@ -64,7 +64,7 @@ The returned instance will fire events that can be listened for and handled.  Fo
     this.storyplayer.on(REASONER_EVENTS.STORY_END, this.handleStoryEnd)
 ```
 
-The demo index page [here](https://github.com/bbc/storyplayer/blob/main/examples/index.html) shows how this might work in a static HTML context, with simple fetchers all reading from the same single pre-loaded JSON file for the story.
+The demo index page [here](https://github.com/bbc/storyplayer/blob/main/index.html) shows how this might work in a static HTML context, with simple fetchers all reading from the same single pre-loaded JSON file for the story.
 
 Building the library from the repo
 ==================================

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,22 +2,14 @@ version: '3.5'
 
 services:
   storyplayer-dev:
-    image: 107881134874.dkr.ecr.eu-west-1.amazonaws.com/obm-build
-    user: ${DOCKER_USER_ID:-builder}
+    image: node:16
+    user: ${DOCKER_USER_ID:-node}
     working_dir: /storyplayer
     environment:
       - DOCKER=true
       - NODE_ENV=development
       - NPM_CONFIG_LOGLEVEL=warn
-      - HOME=${DOCKER_USER_HOME:-/home/builder}
-      - COSMOS_CERT=/etc/pki/tls/certs/client.crt
-      - COSMOS_CERT_KEY=/etc/pki/tls/private/client.key
-      - COSMOS_KEY=/etc/pki/tls/private/client.key
+      - HOME=${DOCKER_USER_HOME:-/home/node}
     volumes:
       - ./:/storyplayer:rw,cached
-      - ../dev.bbc.co.uk.crt:/etc/pki/tls/certs/client.crt:ro
-      - ../dev.bbc.co.uk.key:/etc/pki/tls/private/client.key:ro
-    command: bash -c '
-      sudo rm /etc/pki/tls/private/client_crt_chain_key.pem &&
-      cat /etc/pki/tls/certs/client.crt /etc/pki/tls/private/client.key | sudo tee -a /etc/pki/tls/private/client_crt_chain_key.pem &&
-      npm run build:watch'
+    command: bash -c 'npm install && npm run build:watch'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3.5'
+
+services:
+  storyplayer-dev:
+    image: 107881134874.dkr.ecr.eu-west-1.amazonaws.com/obm-build
+    user: ${DOCKER_USER_ID:-builder}
+    working_dir: /storyplayer
+    environment:
+      - DOCKER=true
+      - NODE_ENV=development
+      - NPM_CONFIG_LOGLEVEL=warn
+      - HOME=${DOCKER_USER_HOME:-/home/builder}
+      - COSMOS_CERT=/etc/pki/tls/certs/client.crt
+      - COSMOS_CERT_KEY=/etc/pki/tls/private/client.key
+      - COSMOS_KEY=/etc/pki/tls/private/client.key
+    volumes:
+      - ./:/storyplayer:rw,cached
+      - ../dev.bbc.co.uk.crt:/etc/pki/tls/certs/client.crt:ro
+      - ../dev.bbc.co.uk.key:/etc/pki/tls/private/client.key:ro
+    command: bash -c '
+      sudo rm /etc/pki/tls/private/client_crt_chain_key.pem &&
+      cat /etc/pki/tls/certs/client.crt /etc/pki/tls/private/client.key | sudo tee -a /etc/pki/tls/private/client_crt_chain_key.pem &&
+      npm run build:watch'

--- a/examples/main.js
+++ b/examples/main.js
@@ -169,7 +169,7 @@ function run(config) {
     document.getElementById('story-title').textContent = config.stories[0].name;
     jsonEditor.set(config);
 
-    romperInstance = Romper.init({
+    romperInstance = Romper({
         target: document.getElementById('romper-target'),
         staticImageBaseUrl: '/src/assets/images/',
         analyticsLogger: dataObj => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bbc/storyplayer",
-  "version": "1.2.0",
+  "version": "1.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bbc/storyplayer",
-      "version": "1.2.0",
+      "version": "1.2.4",
       "license": "GPL-3.0-only",
       "dependencies": {
         "browser-bunyan": "^1.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/storyplayer",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "StoryPlayer - reference player for BBC Research & Development's object-based media schema (https://www.npmjs.com/package/@bbc/object-based-media-schema)",
   "main": "./dist/storyplayer.js",
   "module": "./dist/storyplayer.js",
@@ -17,6 +17,7 @@
   "scripts": {
     "clean": "rm -rf dist",
     "build": "vite build",
+    "build:watch": "vite build --watch",
     "dev": "vite",
     "test": "concurrently -c red,green,yellow -n t- npm:test-*",
     "test-eslint": "eslint src/",

--- a/src/storyplayer.ts
+++ b/src/storyplayer.ts
@@ -16,6 +16,8 @@ import {
 } from "./browserCapabilities"
 import {getSetting, WEBVIEW_DEBUG_FLAG, UA_DEBUG_FLAG} from "./utils"
 
+import pkg from "../package.json";
+
 import noAssetSvg from "./assets/images/no-asset.svg";
 import blackPng from "./assets/images/black.png"
 
@@ -28,6 +30,9 @@ import {
 
 // import css styles
 import "./assets/styles/player.scss"
+
+const PLAYER_VERSION = pkg.version;
+const SCHEMA_VERSION = pkg.devDependencies["@bbc/object-based-media-schema"];
 
 const DEFAULT_SETTINGS = {
     mediaFetcher: MediaFetcher({}),
@@ -110,8 +115,7 @@ if (getSetting(UA_DEBUG_FLAG)) {
 }
 
 const Romper = (settings: Settings): Controller | null | undefined => {
-    // eslint-disable-next-line no-undef
-    // logger.info('StoryPlayer Version:', playerVersion, 'Schema Version:', schemaVersion);
+    logger.info('StoryPlayer Version:', PLAYER_VERSION, 'Schema Version:', SCHEMA_VERSION);
     const mergedSettings = {...DEFAULT_SETTINGS, ...settings}
 
     if (!mergedSettings.dataResolver) {
@@ -169,8 +173,3 @@ export {
     VARIABLE_EVENTS,
     DOM_EVENTS,
 }
-
-// eslint-disable-next-line no-undef
-// export const playerVersion = __PLAYER_VERSION__;
-// eslint-disable-next-line no-undef
-// export const schemaVersion = __LATEST_SCHEMA_VERSION__;

--- a/src/types/image.d.ts
+++ b/src/types/image.d.ts
@@ -1,0 +1,5 @@
+declare module "*.png";
+declare module "*.jpg";
+declare module "*.jpeg";
+declare module "*.svg";
+declare module "*.gif";

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -242,7 +242,10 @@ export interface SMPPlayListItem {
     href?: Array<Record<string, string>>
     url?: string
     kind?: string
-    captionsUrl?: string
+    captionsUrl?: string,
+    versionID?: string,
+    in?: number,
+    out?: number
 }
 
 export interface SMPPlayList {
@@ -259,7 +262,7 @@ export interface SMPPlayList {
 
 export interface UILogFunction {
     (
-        eventName: string, 
+        eventName: string,
         from?: string,
         to?: string,
     ): void

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,15 +10,15 @@
         "outDir": "./build/",
         "resolveJsonModule": true,
         "sourceMap": true,
-        "suppressExcessPropertyErrors": true,
         "target": "es2019",
         "typeRoots": [
             "@types",
-            "types/",
+            "src/types/",
         ]
     },
     "include": [
-        "src/**/*.ts"
+        "src/**/*.ts",
+        "src/types/image.d.ts"
     ],
     "exclude": [ ],
     "lib": [

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,20 +1,35 @@
 import { defineConfig } from 'vite'
 import { resolve } from 'path'
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
 
-export default defineConfig({
-  publicDir: 'src/assets/public',
-  build: {
-    target: 'es2015',
-    lib: {
-      entry: resolve(__dirname, 'src/storyplayer.ts'),
-      name: 'StoryPlayer',
-      fileName: (format, entryName) => `${entryName}.js`,
-      formats: ['cjs'],
-    },
-    rollupOptions: {
-      output: {
-        assetFileNames: "storyplayer.[ext]",
+export default defineConfig(({ command, mode, ssrBuild }) => {
+
+  const isProduction = mode === "production";
+  const minify = isProduction ? "terser" : "esbuild"; // applies to src code and css
+  const cssCodeSplit = true;  // set to True to force separate css file as its imported in StoryPlayer Harness
+  const sourcemap = isProduction ? false : "inline";
+
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = dirname(__filename);
+
+  return {
+    build: {
+      target: 'es2015',
+      cssCodeSplit,
+      minify,
+      sourcemap,
+      lib: {
+        entry: resolve(__dirname, 'src/storyplayer.ts'),
+        name: 'StoryPlayer',
+        fileName: (format, entryName) => `${entryName}.js`,
+        formats: ['es'],
+      },
+      rollupOptions: {
+        output: {
+          assetFileNames: "storyplayer.[ext]",
+        },
       },
     },
-  },
+  }
 })


### PR DESCRIPTION
# Details
- Changes to Vite JS to build as ES Modules
- Addition of docker compose to bring storyplayer up in watch mode
- Re-do exports from Storyplayer - THIS CHANGES THE DEFAULT EXPORT OF STORYPLAYER (so will need updating in SPH and SF)

# Testing

- Spin up this build in watch mode using `docker compose up`
- Check out https://github.com/bbc/rd-ux-storyplayer-harness/pull/321
- Spin up SPH using `docker compose up` (**NOTE**: the `npm install` in the docker compose file will wipe out any `npm link` commands. So replace "npm install" with "npm link:storyplayer" to get it linked up and working as expected)

# Ticket / issue URL
Ticket / issue URL: 

# PR Checks
(tick as appropriate) 

- [ ] PR is linked to ticket / issue
- [ ] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [ ] PR has the package.json version bumped 
