### PR TITLE
fix: remove location.search calls from SMP plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/storyplayer",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "StoryPlayer - reference player for BBC Research & Development's object-based media schema (https://www.npmjs.com/package/@bbc/object-based-media-schema)",
   "main": "./dist/storyplayer.js",
   "module": "./dist/storyplayer.js",

--- a/src/gui/Player.ts
+++ b/src/gui/Player.ts
@@ -145,9 +145,8 @@ class Player extends EventEmitter {
 
         this.useExternalTransport = () => {
             // eslint-disable-next-line no-restricted-globals
-            const useExternal =
-                new URLSearchParams(parent.location.search).getAll("noUi")
-                    .length > 0 || this._controller.options?.noUi
+            const useExternal = 
+                getSetting("noUi") === "true" || this._controller.options?.noUi
             if (useExternal === undefined) return false
             return useExternal
         }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -87,6 +87,7 @@ export const getCurrentUrl = () => {
     return window.location.href
 }
 export const getVariableOverrides = () => {
+    if (inSMPWrapper) return [];
     const varNames = new URLSearchParams(window.location.search).getAll(
         "varName",
     )


### PR DESCRIPTION
# Details
Prevents SMP plugin from throwing a console error in Chrome, since window.location cannot be used within iframe.

I've only been able to test that the `noUi=true` query parameter still works, as I can't bring up a local SPH instance with a local SP linked.

# Ticket / issue URL
Ticket / issue URL: https://jira.dev.bbc.co.uk/browse/PRODTOOLS-3980

# PR Checks
(tick as appropriate) 

- [x] PR is linked to ticket / issue
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [x] PR has the package.json version bumped 
