### PR TITLE
feat: add shaka preload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@bbc/storyplayer",
-  "version": "1.4.0",
+  "version": "1.4.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bbc/storyplayer",
-      "version": "1.4.0",
+      "version": "1.4.4",
       "license": "GPL-3.0-only",
       "dependencies": {
         "browser-bunyan": "^1.5.3",
         "eventemitter3": "^5.0.0",
         "json-logic-js": "^2.0.0",
-        "shaka-player": "^4.3.5",
+        "shaka-player": "^4.10.8",
         "three": "^0.148.0",
         "uuid": "^9.0.0"
       },
@@ -1406,9 +1406,9 @@
       }
     },
     "node_modules/eme-encryption-scheme-polyfill": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/eme-encryption-scheme-polyfill/-/eme-encryption-scheme-polyfill-2.1.1.tgz",
-      "integrity": "sha512-njD17wcUrbqCj0ArpLu5zWXtaiupHb/2fIUQGdInf83GlI+Q6mmqaPGLdrke4savKAu15J/z1Tg/ivDgl14g0g=="
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/eme-encryption-scheme-polyfill/-/eme-encryption-scheme-polyfill-2.1.5.tgz",
+      "integrity": "sha512-z9BKXV4TCYjmar0wiZLObZ0J8HE13VIg7Zq/iyPWdbEfROtxVXEJalknWKtBR5XNezzy15/zWS964TGbcAWlPg=="
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -4601,11 +4601,11 @@
       "dev": true
     },
     "node_modules/shaka-player": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/shaka-player/-/shaka-player-4.3.6.tgz",
-      "integrity": "sha512-IX0rJY9NZyENcFH3MDf50cpOLOBsWWdaX8D3Fy0kSl7j1D1I+sXrzOQ2LxFgwmlqbIX3XrHzY9bxiWapV3ZjEg==",
+      "version": "4.10.8",
+      "resolved": "https://registry.npmjs.org/shaka-player/-/shaka-player-4.10.8.tgz",
+      "integrity": "sha512-kYeZrcW7qdjLt+oGaX+V5yzLnpIdbCUxDrzpC42vzCTMjHDCFci/sksRhc+oTAiHFhmDuzx12WmBMg4N79SVwg==",
       "dependencies": {
-        "eme-encryption-scheme-polyfill": "^2.1.1"
+        "eme-encryption-scheme-polyfill": "^2.1.5"
       },
       "engines": {
         "node": ">=14"
@@ -6367,9 +6367,9 @@
       }
     },
     "eme-encryption-scheme-polyfill": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/eme-encryption-scheme-polyfill/-/eme-encryption-scheme-polyfill-2.1.1.tgz",
-      "integrity": "sha512-njD17wcUrbqCj0ArpLu5zWXtaiupHb/2fIUQGdInf83GlI+Q6mmqaPGLdrke4savKAu15J/z1Tg/ivDgl14g0g=="
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/eme-encryption-scheme-polyfill/-/eme-encryption-scheme-polyfill-2.1.5.tgz",
+      "integrity": "sha512-z9BKXV4TCYjmar0wiZLObZ0J8HE13VIg7Zq/iyPWdbEfROtxVXEJalknWKtBR5XNezzy15/zWS964TGbcAWlPg=="
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -8835,11 +8835,11 @@
       "dev": true
     },
     "shaka-player": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/shaka-player/-/shaka-player-4.3.6.tgz",
-      "integrity": "sha512-IX0rJY9NZyENcFH3MDf50cpOLOBsWWdaX8D3Fy0kSl7j1D1I+sXrzOQ2LxFgwmlqbIX3XrHzY9bxiWapV3ZjEg==",
+      "version": "4.10.8",
+      "resolved": "https://registry.npmjs.org/shaka-player/-/shaka-player-4.10.8.tgz",
+      "integrity": "sha512-kYeZrcW7qdjLt+oGaX+V5yzLnpIdbCUxDrzpC42vzCTMjHDCFci/sksRhc+oTAiHFhmDuzx12WmBMg4N79SVwg==",
       "requires": {
-        "eme-encryption-scheme-polyfill": "^2.1.1"
+        "eme-encryption-scheme-polyfill": "^2.1.5"
       }
     },
     "shebang-command": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "browser-bunyan": "^1.5.3",
     "eventemitter3": "^5.0.0",
     "json-logic-js": "^2.0.0",
-    "shaka-player": "^4.3.5",
+    "shaka-player": "^4.10.8",
     "three": "^0.148.0",
     "uuid": "^9.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/storyplayer",
-  "version": "1.4.4",
+  "version": "1.4.6",
   "description": "StoryPlayer - reference player for BBC Research & Development's object-based media schema (https://www.npmjs.com/package/@bbc/object-based-media-schema)",
   "main": "./dist/storyplayer.js",
   "module": "./dist/storyplayer.js",

--- a/src/playoutEngines/DOMSwitchPlayoutEngine.ts
+++ b/src/playoutEngines/DOMSwitchPlayoutEngine.ts
@@ -387,7 +387,11 @@ export default class DOMSwitchPlayoutEngine extends BasePlayoutEngine {
                 )
 
                 rendererPlayoutObj._shaka
-                    .load(url)
+                    .preload(url)
+                    .then((preloadManager) => {
+                        logger.info(`Preloaded ${url}`)
+                        return rendererPlayoutObj._shaka.load(preloadManager)
+                    })
                     .then(() => {
                         logger.info(`Loaded ${url}`)
                     })


### PR DESCRIPTION
# Details
Adds the recent shaka player feature `preload` to the DOM player engine, used for DASH and non-native HLS. The preload step fetches further media segments, ahead of playback, than a default load resulting in a better transition between media. 

Fairly easy win as story objects already contains and loads the next media in the narrative before playback, so preloading is a  limited but impactful code change.

Also includes shaka-player version bump to 4.10.8

# Ticket / issue URL
Ticket / issue URL: https://jira.dev.bbc.co.uk/browse/PRODTOOLS-4027

# PR Checks
(tick as appropriate) 

- [x] PR is linked to ticket / issue
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [x] PR has the package.json version bumped 
