### PR TITLE
chore: upgrade nodejs to maintenance and lts (18 and 20)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        version: [16, 18]
+        version: [18, 20]
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The [examples code](https://github.com/bbc/storyplayer/blob/main/examples/main.j
 Building the library from the repo
 ==================================
 
-> Ensure you have NodeJS v16 installed.
+> Ensure you have NodeJS v20 installed.
 > We use NPM for dependency management and building.\
 > We have an ESLint file based on the `typescript-eslint` parser.\
 > We have moved from Flow to TypeScript for type-checking, albeit the types are fairly permissive.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.5'
 
 services:
   storyplayer-dev:
-    image: node:16
+    image: node:20
     user: ${DOCKER_USER_ID:-node}
     working_dir: /storyplayer
     environment:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bbc/storyplayer",
-  "version": "1.4.4",
+  "version": "1.4.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bbc/storyplayer",
-      "version": "1.4.4",
+      "version": "1.4.6",
       "license": "GPL-3.0-only",
       "dependencies": {
         "browser-bunyan": "^1.5.3",
@@ -18,7 +18,7 @@
       },
       "devDependencies": {
         "@bbc/object-based-media-schema": "^1.0.4",
-        "@types/node": "^18.11.18",
+        "@types/node": "^20.16.11",
         "@typescript-eslint/eslint-plugin": "^5.48.0",
         "@typescript-eslint/parser": "^5.48.0",
         "concurrently": "^5.3.0",
@@ -564,10 +564,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.14.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.5.tgz",
-      "integrity": "sha512-CRT4tMK/DHYhw1fcCEBwME9CSaZNclxfzVMe7GsO6ULSwsttbj70wSiX6rZdIjGblu93sTJxLdhNIT85KKI7Qw==",
-      "dev": true
+      "version": "20.16.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.11.tgz",
+      "integrity": "sha512-y+cTCACu92FyA5fgQSAI8A1H429g7aSK2HsO7K4XYUWc4dY5IUz55JSDIYT6/VsOLfGy8vmvQYC2hfb0iF16Uw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
     },
     "node_modules/@types/semver": {
       "version": "7.3.13",
@@ -5074,6 +5077,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true
+    },
     "node_modules/universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -5770,10 +5779,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.14.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.5.tgz",
-      "integrity": "sha512-CRT4tMK/DHYhw1fcCEBwME9CSaZNclxfzVMe7GsO6ULSwsttbj70wSiX6rZdIjGblu93sTJxLdhNIT85KKI7Qw==",
-      "dev": true
+      "version": "20.16.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.11.tgz",
+      "integrity": "sha512-y+cTCACu92FyA5fgQSAI8A1H429g7aSK2HsO7K4XYUWc4dY5IUz55JSDIYT6/VsOLfGy8vmvQYC2hfb0iF16Uw==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~6.19.2"
+      }
     },
     "@types/semver": {
       "version": "7.3.13",
@@ -9200,6 +9212,12 @@
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true
     },
     "universalify": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "homepage": "https://github.com/bbc/storyplayer#readme",
   "devDependencies": {
     "@bbc/object-based-media-schema": "^1.0.4",
-    "@types/node": "^18.11.18",
+    "@types/node": "^20.16.11",
     "@typescript-eslint/eslint-plugin": "^5.48.0",
     "@typescript-eslint/parser": "^5.48.0",
     "concurrently": "^5.3.0",


### PR DESCRIPTION
# Details
Node 16 is EOL, this bumps the build image and github action workflows to 18 and 20.

# Ticket / issue URL
Ticket / issue URL: 
https://jira.dev.bbc.co.uk/browse/PRODTOOLS-4144
https://jira.dev.bbc.co.uk/browse/PRODTOOLS-4020

# PR Checks
(tick as appropriate) 

- [x] PR is linked to ticket / issue
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [ ] PR has the package.json version bumped 
